### PR TITLE
fix: improve Error Trace output

### DIFF
--- a/internal/assertions/testing.go
+++ b/internal/assertions/testing.go
@@ -92,6 +92,10 @@ func isTest(name, prefix string) bool {
 }
 
 func errorWithCallerInfo(t T, offset int, failureMessage string, msgAndArgs ...any) {
+	if h, ok := t.(H); ok {
+		h.Helper()
+	}
+
 	content := []labeledContent{
 		{"Error Trace", strings.Join(callerInfo(offset), "\n\t\t\t")},
 		{"Error", failureMessage},


### PR DESCRIPTION
## Change type

🔧 Bug fix

## Short description
When using EventuallyWith the failure always show the `testing.go:110` as the source which makes things hard to debug. 
This PR resolves that issue.

## Fixes

```golang
package cache

import (
	"testing"
	"time"

	"github.com/go-openapi/testify/v2/assert"
)

func TestExample_Failure(t *testing.T) {
	assert.EventuallyWith(t, func(collect *assert.CollectT) {
		time.Sleep(time.Millisecond)
	}, 2*time.Microsecond, time.Microsecond)
}
```

Current behavior
```
=== RUN   TestExample_Failure
    condition.go:558: context deadline exceeded
    testing.go:110: 
        	Error Trace:	/home/warnar/.asdf/installs/golang/1.26.2/go/src/runtime/asm_amd64.s:1771
        	Error:      	condition never satisfied
        	Test:       	TestExample_Failure
    condition.go:334: context deadline exceeded
--- FAIL: TestExample_Failure (0.00s)

FAIL
```

New behavior
```
=== RUN   TestExample_Failure
    example_test.go:11:
        	Error Trace:	example_test.go:11
        	Error:      	condition never satisfied
        	Test:       	TestExample_Failure
--- FAIL: TestExample_Failure (0.00s)

FAIL
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
