### PR TITLE
doc: variabilized various metrics in docs using codegen counts.

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,5 +77,5 @@ that require external deps.
 ## Module Information
 
 - Module path: `github.com/go-openapi/testify/v2`
-- Go version: 1.24.0
+- Go version: 1.25.0
 - License: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is the go-openapi fork of the great [testify](https://github.com/stretchr/t
 * 95% compatible with `stretchr/testify` — if you already use it, our migration tool automates the switch
 * Actively maintained: regular fixes and evolutions, many PRs proposed upstream are already in
 * Zero external dependencies — you import what you need, with opt-in modules for extras (e.g. YAML, colorized output)
-* Modernized codebase targeting go1.24+
+* Modernized codebase targeting go1.25+
 * Go routine leak detection built in: zero-setup, no false positives, works with parallel tests (unlike `go.uber.org/goleak`)
 * File descriptor leak detection (linux-only)
 * Type-safe assertions with generics (see [a basic example][example-with-generics-url]) — migration to generics can be automated too. [Read the full story][doc-generics]
@@ -37,7 +37,7 @@ This is the go-openapi fork of the great [testify](https://github.com/stretchr/t
 ### This fork isn't for everyone
 
 * You need the `mock` package — we removed it and won't bring it back. For suites, we're [open to discussion][suite-discussion] about a redesigned approach
-* Your project must support Go versions older than 1.24
+* Your project must support Go versions older than 1.25
 * You rely on `testifylint` or other tooling that expects the `stretchr/testify` import path
 * You need 100% API compatibility — we're at 95%, and the remaining 5% are intentional removals
 
@@ -60,31 +60,7 @@ Feedback, contributions and proposals are welcome.
 
 > **Recent news**
 >
-> ✅ Stabibilized API
->
-> ✅ Migration tool
->
-> ✅ Fully refactored how assertions are generated and documented. Opt-in features with their dependencies.
->
-> Fixes
->
-> ✅ Fixed hangs & panics when using `spew`. Fuzzed `spew`. Fixed deterministic order of keys in diff.
->
-> ✅ Fixed go routine leaks with `EventuallyWith` and co.
->
-> ✅ Fixed wrong logic with `IsNonIncreasing`, `InNonDecreasing`
->
-> ✅ Fixed edge cases with `InDelta`, `InEpsilon`
->
-> ✅ Fixed edge cases with `EqualValues`
->
-> Additions
->
-> ✅ Introduced generics: ~ 40 new type-safe assertions with generic types (doc: added usage guide, examples and benchmark)
->
-> ✅ Added `Kind` & `NotKind`, `Consistently`, `NoGoRoutineLeak`, `NoFileDescriptorLeak`
->
-> ✅ Added opt-in support for colorized output
+> ✅ Preparing v2.5.0: new features, a few fixes (`EventuallyWithT`)
 >
 > See also our [ROADMAP][doc-roadmap].
 

--- a/assert/assert_assertions.go
+++ b/assert/assert_assertions.go
@@ -1311,6 +1311,12 @@ func IsIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, m
 
 // IsNonDecreasing asserts that the collection is not strictly decreasing.
 //
+// This is the logical negation of [IsDecreasing]: it succeeds whenever
+// [IsDecreasing] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [3, 1, 2]).
+//
+// It is NOT the same as "weakly increasing" (a[i] <= a[i+1] for all i).
+//
 // # Usage
 //
 //	assertions.IsNonDecreasing(t, []int{1, 1, 2})
@@ -1330,7 +1336,13 @@ func IsNonDecreasing(t T, collection any, msgAndArgs ...any) bool {
 	return assertions.IsNonDecreasing(t, collection, msgAndArgs...)
 }
 
-// IsNonDecreasingT asserts that a slice of [Ordered] is not decreasing.
+// IsNonDecreasingT asserts that a slice of [Ordered] is NOT strictly decreasing.
+//
+// This is the logical negation of [IsDecreasingT]: it succeeds whenever
+// [IsDecreasingT] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [3, 1, 2]).
+//
+// It is NOT the same as "weakly increasing" (a[i] <= a[i+1] for all i).
 //
 // # Usage
 //
@@ -1351,7 +1363,13 @@ func IsNonDecreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice
 	return assertions.IsNonDecreasingT[OrderedSlice, E](t, collection, msgAndArgs...)
 }
 
-// IsNonIncreasing asserts that the collection is not increasing.
+// IsNonIncreasing asserts that the collection is not strictly increasing.
+//
+// This is the logical negation of [IsIncreasing]: it succeeds whenever
+// [IsIncreasing] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [1, 3, 2]).
+//
+// It is NOT the same as "weakly decreasing" (a[i] >= a[i+1] for all i).
 //
 // # Usage
 //
@@ -1374,11 +1392,17 @@ func IsNonIncreasing(t T, collection any, msgAndArgs ...any) bool {
 
 // IsNonIncreasingT asserts that a slice of [Ordered] is NOT strictly increasing.
 //
+// This is the logical negation of [IsIncreasingT]: it succeeds whenever
+// [IsIncreasingT] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [1, 3, 2]).
+//
+// It is NOT the same as "weakly decreasing" (a[i] >= a[i+1] for all i).
+//
 // # Usage
 //
-//	assertions.IsNonIncreasing(t, []int{2, 1, 1})
-//	assertions.IsNonIncreasing(t, []float{2, 1})
-//	assertions.IsNonIncreasing(t, []string{"b", "a"})
+//	assertions.IsNonIncreasingT(t, []int{2, 1, 1})
+//	assertions.IsNonIncreasingT(t, []float{2, 1})
+//	assertions.IsNonIncreasingT(t, []string{"b", "a"})
 //
 // # Examples
 //

--- a/codegen/internal/generator/doc_generator.go
+++ b/codegen/internal/generator/doc_generator.go
@@ -4,12 +4,16 @@
 package generator
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"iter"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
+
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/go-openapi/testify/codegen/v2/internal/generator/domains"
 	"github.com/go-openapi/testify/codegen/v2/internal/generator/funcmaps"
@@ -19,9 +23,12 @@ import (
 
 const (
 	// index page metadata.
-	indexTitle       = "Assertions index"
-	indexDescription = "Index of assertion domains"
-	indexFile        = "_index.md"
+	indexTitle         = "Assertions index"
+	indexDescription   = "Index of assertion domains"
+	indexFile          = "_index.md"
+	metricsTitle       = "Quick API index"
+	metricsDescription = "API quick index & metrics"
+	metricsFile        = "metrics.md"
 
 	// sensible default preallocated slots.
 	allocatedEntries = 15
@@ -78,7 +85,11 @@ func (d *DocGenerator) Generate(opts ...GenerateOption) error {
 		}
 	}
 
-	return nil
+	if err := d.generateMetricsPage(indexDoc); err != nil {
+		return err
+	}
+
+	return d.writeYAMLMetrics(indexDoc.Metrics)
 }
 
 type uniqueValues struct {
@@ -173,6 +184,8 @@ func (d *DocGenerator) buildIndexDocument(docsByDomain iter.Seq2[string, model.D
 	}
 
 	doc.RefCount = len(doc.Index)
+	doc.Metrics = buildMetrics(docsByDomain)
+	doc.QuickIndex = buildQuickIndex(docsByDomain)
 
 	return doc
 }
@@ -196,6 +209,95 @@ func buildIndexEntries(docsByDomain iter.Seq2[string, model.Document]) []model.I
 	return entries
 }
 
+func buildMetrics(docsByDomain iter.Seq2[string, model.Document]) (metrics model.Metrics) {
+	metrics.ByDomain = make(map[string]model.DomainMetrics)
+
+	for domain, doc := range docsByDomain {
+		metrics.Domains++
+		var domainMetrics model.DomainMetrics
+		domainMetrics.Name = doc.Title
+		for _, fn := range doc.Package.Functions {
+			metrics.Functions++
+
+			if fn.IsHelper {
+				metrics.Helpers++
+				continue
+			}
+
+			if fn.IsConstructor {
+				metrics.Others++
+				continue
+			}
+
+			metrics.Assertions++
+			domainMetrics.Count++
+
+			if fn.IsGeneric {
+				metrics.Generics++
+			}
+		}
+
+		metrics.ByDomain[domain] = domainMetrics
+	}
+
+	metrics.NonGenerics = metrics.Functions - metrics.Generics
+
+	return metrics
+}
+
+func buildQuickIndex(docsByDomain iter.Seq2[string, model.Document]) model.QuickIndex {
+	const sensibleAlloc = 150
+	index := make(model.QuickIndex, 0, sensibleAlloc)
+	seen := make(map[string]struct{}, sensibleAlloc)
+	opposites := make(map[string]string, sensibleAlloc)
+
+	genericNames := make(map[string]string, sensibleAlloc)
+	for _, doc := range docsByDomain {
+		for _, fn := range doc.Package.Functions {
+			genericNames[fn.Name] = fn.GenericName()
+			for _, tag := range fn.ExtraComments {
+				opposite := tag.Opposite()
+				if opposite != "" {
+					seen[opposite] = struct{}{}
+					opposites[fn.Name] = opposite
+					break
+				}
+			}
+		}
+	}
+
+	for domain, doc := range docsByDomain {
+		for _, fn := range doc.Package.Functions {
+			_, isOpposite := seen[fn.Name]
+			if isOpposite {
+				continue
+			}
+
+			opposite := opposites[fn.Name]
+			entry := model.QuickIndexEntry{
+				Name:      fn.GenericName(),
+				Anchor:    funcmaps.Slugize(fn.GenericName()),
+				Opposite:  opposite,
+				Domain:    domain,
+				IsGeneric: fn.IsGeneric,
+				IsHelper:  fn.IsHelper,
+			}
+			if opposite != "" {
+				if gn, ok := genericNames[opposite]; ok {
+					entry.OppositeAnchor = funcmaps.Slugize(gn)
+				}
+			}
+
+			index = append(index, entry)
+		}
+	}
+
+	slices.SortFunc(index, func(a, b model.QuickIndexEntry) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return index
+}
+
 func (d *DocGenerator) generateDomainIndex(document model.Document) error {
 	base := filepath.Join(d.ctx.targetRoot, d.ctx.targetDoc, document.Path)
 	if err := os.MkdirAll(base, dirPermissions); err != nil {
@@ -213,6 +315,19 @@ func (d *DocGenerator) generateDomainPage(document model.Document) error {
 	return d.render("doc_page", filepath.Join(base, document.File), document)
 }
 
+func (d *DocGenerator) generateMetricsPage(document model.Document) error {
+	document.File = metricsFile
+	document.Title = metricsTitle
+	document.Description = metricsDescription
+
+	base := filepath.Join(d.ctx.targetRoot, d.ctx.targetDoc, document.Path)
+	if err := os.MkdirAll(base, dirPermissions); err != nil {
+		return fmt.Errorf("can't make target folder: %w", err)
+	}
+
+	return d.render("doc_metrics", filepath.Join(base, document.File), document)
+}
+
 func (d *DocGenerator) loadTemplates() error {
 	const (
 		tplExt            = ".md.gotmpl"
@@ -222,6 +337,7 @@ func (d *DocGenerator) loadTemplates() error {
 	index := make(map[string]string, expectedTemplates)
 	index["doc_index"] = "doc_index"
 	index["doc_page"] = "doc_page"
+	index["doc_metrics"] = "doc_metrics"
 
 	templates, err := loadTemplatesFromIndex(index, tplExt, templatesFS)
 	if err != nil {
@@ -330,4 +446,29 @@ func (d *DocGenerator) render(name string, target string, data any) error {
 		data,
 		renderMD,
 	)
+}
+
+// writeYAMLMetrics writes the Metrics structure as a YAML file in the hugo generation folder.
+//
+// This allows doc pages to use metrics directly with shortcodes.
+func (d *DocGenerator) writeYAMLMetrics(metrics model.Metrics) error {
+	base := filepath.Join(d.ctx.targetRoot, "hack", "doc-site", "hugo")
+	if err := os.MkdirAll(base, dirPermissions); err != nil {
+		return fmt.Errorf("can't make target folder: %w", err)
+	}
+	target := filepath.Join(base, "metrics.yaml")
+
+	type containerT struct {
+		Params struct {
+			Metrics model.Metrics `yaml:"metrics"`
+		} `yaml:"params"`
+	}
+	var container containerT
+	container.Params.Metrics = metrics
+	buf, err := yaml.Marshal(container)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(target, buf, filePermissions)
 }

--- a/codegen/internal/generator/funcmaps/funcmaps.go
+++ b/codegen/internal/generator/funcmaps/funcmaps.go
@@ -59,7 +59,7 @@ func FuncMap() template.FuncMap {
 		"returns":          PrintReturns,
 		"sourceLink":       sourceLink,
 		"titleize":         titleize,
-		"slugize":          slugize,
+		"slugize":          Slugize,
 		"blockquote":       blockquote,
 		"hopen":            hugoopen,
 		"hclose":           hugoclose,
@@ -353,8 +353,8 @@ func printDate() string {
 	return time.Now().Format(time.DateOnly)
 }
 
-// slugize converts a name into a markdown ref inside a document.
-func slugize(in string) string {
+// Slugize converts a name into a markdown ref inside a document.
+func Slugize(in string) string {
 	return strings.ToLower(
 		strings.Map(func(r rune) rune {
 			switch r {

--- a/codegen/internal/generator/funcmaps/funcmaps_test.go
+++ b/codegen/internal/generator/funcmaps/funcmaps_test.go
@@ -822,8 +822,8 @@ func TestSlugize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := slugize(tt.input); got != tt.expected {
-				t.Errorf("slugize(%q) = %q, want %q", tt.input, got, tt.expected)
+			if got := Slugize(tt.input); got != tt.expected {
+				t.Errorf("Slugize(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}

--- a/codegen/internal/generator/templates/doc_metrics.md.gotmpl
+++ b/codegen/internal/generator/templates/doc_metrics.md.gotmpl
@@ -1,0 +1,37 @@
+---
+title: {{ .Title | quote }}
+description: |
+  {{ titleize .Description }}.
+weight: -1
+---
+
+{{- with .Metrics }}
+
+## Domains
+
+All assertions are classified into **{{ .Domains }}** domains to help navigate the API, depending on your use case.
+
+## API metrics
+
+Counts for core functionality, excluding variants (formatted, forward, forward-formatted).
+
+| Kind                     | Count             |
+| ------------------------ | ----------------- |
+| All functions            | {{ .Functions }}  |
+| All core assertions      | {{ .Assertions }} |
+| Generic assertions       | {{ .Generics }}   |
+| Helpers (not assertions) | {{ .Helpers }}    |
+| Others                   | {{ .Others }}     |
+
+{{- end }}
+
+## Quick index
+
+Table of core assertions, excluding variants. Each function is side by side with its logical opposite (when available).
+
+| Assertion                | Opposite          | Domain | Kind |
+| ------------------------ | ----------------- | ------ | ---- |
+{{- range .QuickIndex }}
+| [{{ .Name }}]({{ .Domain }}/#{{ .Anchor }}){{ if .IsGeneric }} {{ hopen }}% icon icon="star" color=orange %{{ hclose }}{{ end }} | {{ if .Opposite }}[{{ .Opposite }}]({{ .Domain }}/#{{ .OppositeAnchor }}){{ end }} | {{ .Domain }} | {{ if .IsHelper }}helper{{ end }} |
+{{- end }}
+

--- a/codegen/internal/model/documentation.go
+++ b/codegen/internal/model/documentation.go
@@ -85,6 +85,8 @@ type Document struct {
 	ExtraPackages ExtraPackages
 	RefCount      int
 	Weight        int
+	Metrics       Metrics
+	QuickIndex    QuickIndex
 }
 
 func (d Document) HasGenerics() bool {
@@ -145,4 +147,33 @@ type IndexEntry struct {
 	Link        string
 	RefCount    int
 	Weight      int
+}
+
+//nolint:tagliatelle // not using camelcase
+type Metrics struct {
+	Domains     int                      `yaml:"domains"`
+	Functions   int                      `yaml:"functions"`
+	Assertions  int                      `yaml:"assertions"`
+	Generics    int                      `yaml:"generics"`
+	NonGenerics int                      `yaml:"nongeneric_assertions"`
+	Helpers     int                      `yaml:"helpers"`
+	Others      int                      `yaml:"others"`
+	ByDomain    map[string]DomainMetrics `yaml:"by_domain"`
+}
+
+type DomainMetrics struct {
+	Name  string `yaml:"name"`
+	Count int    `yaml:"count"`
+}
+
+type QuickIndex []QuickIndexEntry
+
+type QuickIndexEntry struct {
+	Name           string
+	Anchor         string
+	Opposite       string
+	OppositeAnchor string
+	Domain         string
+	IsGeneric      bool
+	IsHelper       bool
 }

--- a/codegen/internal/model/model.go
+++ b/codegen/internal/model/model.go
@@ -437,6 +437,7 @@ const (
 	CommentTagMention
 	CommentTagNote
 	CommentTagDomainDescription
+	CommentTagOpposite
 )
 
 type ExtraComment struct {
@@ -455,4 +456,12 @@ func (c ExtraComment) IsTagMention() bool {
 
 func (c ExtraComment) IsTagNote() bool {
 	return c.Tag == CommentTagNote
+}
+
+func (c ExtraComment) Opposite() string {
+	if c.Tag != CommentTagOpposite {
+		return ""
+	}
+
+	return c.Text
 }

--- a/codegen/internal/scanner/comments-parser/tags.go
+++ b/codegen/internal/scanner/comments-parser/tags.go
@@ -18,6 +18,7 @@ import (
 //   - maintainer: <value>       - multi-line maintainer note
 //   - note: <value>             - multi-line note
 //   - mention: <value>          - single-line mention
+//   - opposite: <value>         - name of the logical opposite assertion (if any)
 //
 // Multi-line tags continue until the next tagged line or end of text.
 func ParseTaggedComments(text string) []model.ExtraComment {
@@ -26,6 +27,7 @@ func ParseTaggedComments(text string) []model.ExtraComment {
 		maintainerPrefix = "maintainer"
 		notePrefix       = "note"
 		mentionPrefix    = "mention"
+		oppositePrefix   = "opposite"
 	)
 
 	inValue := false
@@ -33,6 +35,7 @@ func ParseTaggedComments(text string) []model.ExtraComment {
 	startValueMaintainer := StartValueFunc(maintainerPrefix)
 	startValueNote := StartValueFunc(notePrefix)
 	startValueMention := StartValueFunc(mentionPrefix)
+	startValueOpposite := StartValueFunc(oppositePrefix)
 
 	startTaggedValue := func(line string) (key string, val string, tag model.CommentTag, multiline bool, ok bool) {
 		val, ok = startValueDomain(line)
@@ -50,6 +53,10 @@ func ParseTaggedComments(text string) []model.ExtraComment {
 		val, ok = startValueMention(line)
 		if ok {
 			return "", val, model.CommentTagMention, false, true
+		}
+		val, ok = startValueOpposite(line)
+		if ok {
+			return "", val, model.CommentTagOpposite, false, true
 		}
 
 		return "", "", model.CommentTagNone, false, false

--- a/docs/doc-site/api/boolean.md
+++ b/docs/doc-site/api/boolean.md
@@ -141,7 +141,7 @@ func main() {
 |--|--|
 | [`assertions.False(t T, value bool, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#False) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#False](https://github.com/go-openapi/testify/blob/master/internal/assertions/boolean.go#L65)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#False](https://github.com/go-openapi/testify/blob/master/internal/assertions/boolean.go#L67)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -252,7 +252,7 @@ func main() {
 |--|--|
 | [`assertions.FalseT[B Boolean](t T, value B, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#FalseT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FalseT](https://github.com/go-openapi/testify/blob/master/internal/assertions/boolean.go#L92)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FalseT](https://github.com/go-openapi/testify/blob/master/internal/assertions/boolean.go#L94)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -474,7 +474,7 @@ func main() {
 |--|--|
 | [`assertions.TrueT[B Boolean](t T, value B, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#TrueT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#TrueT](https://github.com/go-openapi/testify/blob/master/internal/assertions/boolean.go#L43)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#TrueT](https://github.com/go-openapi/testify/blob/master/internal/assertions/boolean.go#L44)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/collection.md
+++ b/docs/doc-site/api/collection.md
@@ -314,7 +314,7 @@ func main() {
 |--|--|
 | [`assertions.ElementsMatch(t T, listA any, listB any, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#ElementsMatch) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ElementsMatch](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L539)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ElementsMatch](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L546)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -423,7 +423,7 @@ func main() {
 |--|--|
 | [`assertions.ElementsMatchT[E comparable](t T, listA []E, listB []E, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#ElementsMatchT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ElementsMatchT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L612)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ElementsMatchT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L620)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -654,7 +654,7 @@ func main() {
 |--|--|
 | [`assertions.MapContainsT[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#MapContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L178)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L182)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -766,7 +766,7 @@ func main() {
 |--|--|
 | [`assertions.MapEqualT[K, V comparable](t T, listA map[K]V, listB map[K]V, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#MapEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L733)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L743)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -873,7 +873,7 @@ func main() {
 |--|--|
 | [`assertions.MapNotContainsT[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#MapNotContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L309)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L314)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -984,7 +984,7 @@ func main() {
 |--|--|
 | [`assertions.MapNotEqualT[K, V comparable](t T, listA map[K]V, listB map[K]V, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#MapNotEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapNotEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L757)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#MapNotEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L768)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1098,7 +1098,7 @@ func main() {
 |--|--|
 | [`assertions.NotContains(t T, s any, contains any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotContains) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotContains](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L205)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotContains](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L210)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1214,7 +1214,7 @@ func main() {
 |--|--|
 | [`assertions.NotElementsMatch(t T, listA any, listB any, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotElementsMatch) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotElementsMatch](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L576)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotElementsMatch](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L584)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1326,7 +1326,7 @@ func main() {
 |--|--|
 | [`assertions.NotElementsMatchT[E comparable](t T, listA []E, listB []E, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotElementsMatchT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotElementsMatchT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L648)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotElementsMatchT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L657)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1443,7 +1443,7 @@ func main() {
 |--|--|
 | [`assertions.NotSubset(t T, list any, subset any, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotSubset) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSubset](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L445)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSubset](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L452)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1556,7 +1556,7 @@ func main() {
 |--|--|
 | [`assertions.SeqContainsT[E comparable](t T, iter iter.Seq[E], element E, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SeqContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SeqContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L149)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SeqContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L152)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1667,7 +1667,7 @@ func main() {
 |--|--|
 | [`assertions.SeqNotContainsT[E comparable](t T, iter iter.Seq[E], element E, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SeqNotContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SeqNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L284)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SeqNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L289)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1776,7 +1776,7 @@ func main() {
 |--|--|
 | [`assertions.SliceContainsT[Slice ~[]E, E comparable](t T, s Slice, element E, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SliceContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L120)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L122)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1888,7 +1888,7 @@ func main() {
 |--|--|
 | [`assertions.SliceEqualT[E comparable](t T, listA []E, listB []E, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SliceEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L684)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L693)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1997,7 +1997,7 @@ func main() {
 |--|--|
 | [`assertions.SliceNotContainsT[Slice ~[]E, E comparable](t T, s Slice, element E, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SliceNotContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L259)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L264)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2108,7 +2108,7 @@ func main() {
 |--|--|
 | [`assertions.SliceNotEqualT[E comparable](t T, listA []E, listB []E, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SliceNotEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceNotEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L708)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceNotEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L718)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2215,7 +2215,7 @@ func main() {
 |--|--|
 | [`assertions.SliceNotSubsetT[Slice ~[]E, E comparable](t T, list Slice, subset Slice, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SliceNotSubsetT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceNotSubsetT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L512)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceNotSubsetT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L519)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2322,7 +2322,7 @@ func main() {
 |--|--|
 | [`assertions.SliceSubsetT[Slice ~[]E, E comparable](t T, list Slice, subset Slice, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SliceSubsetT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceSubsetT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L414)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SliceSubsetT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L420)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2431,7 +2431,7 @@ func main() {
 |--|--|
 | [`assertions.StringContainsT[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#StringContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#StringContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L93)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#StringContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L94)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2540,7 +2540,7 @@ func main() {
 |--|--|
 | [`assertions.StringNotContainsT[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#StringNotContainsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#StringNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L234)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#StringNotContainsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L239)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2660,7 +2660,7 @@ func main() {
 |--|--|
 | [`assertions.Subset(t T, list any, subset any, msgAndArgs ...any) (ok bool)`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Subset) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Subset](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L344)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Subset](https://github.com/go-openapi/testify/blob/master/internal/assertions/collection.go#L349)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/comparison.md
+++ b/docs/doc-site/api/comparison.md
@@ -286,7 +286,7 @@ func main() {
 |--|--|
 | [`assertions.GreaterOrEqual(t T, e1 any, e2 any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#GreaterOrEqual) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#GreaterOrEqual](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L91)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#GreaterOrEqual](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L93)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -407,7 +407,7 @@ func main() {
 |--|--|
 | [`assertions.GreaterOrEqualT[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#GreaterOrEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#GreaterOrEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L124)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#GreaterOrEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L127)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -527,7 +527,7 @@ func main() {
 |--|--|
 | [`assertions.GreaterT[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#GreaterT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#GreaterT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L62)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#GreaterT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L63)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -643,7 +643,7 @@ func main() {
 |--|--|
 | [`assertions.Less(t T, e1 any, e2 any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Less) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Less](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L153)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Less](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L157)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -757,7 +757,7 @@ func main() {
 |--|--|
 | [`assertions.LessOrEqual(t T, e1 any, e2 any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#LessOrEqual) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#LessOrEqual](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L211)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#LessOrEqual](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L215)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -877,7 +877,7 @@ func main() {
 |--|--|
 | [`assertions.LessOrEqualT[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#LessOrEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#LessOrEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L243)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#LessOrEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L247)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -996,7 +996,7 @@ func main() {
 |--|--|
 | [`assertions.LessT[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#LessT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#LessT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L184)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#LessT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L188)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1108,7 +1108,7 @@ func main() {
 |--|--|
 | [`assertions.Negative(t T, e any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Negative) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Negative](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L314)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Negative](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L320)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1216,7 +1216,7 @@ func main() {
 |--|--|
 | [`assertions.NegativeT[SignedNumber SignedNumeric](t T, e SignedNumber, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NegativeT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NegativeT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L335)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NegativeT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L341)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1328,7 +1328,7 @@ func main() {
 |--|--|
 | [`assertions.Positive(t T, e any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Positive) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Positive](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L268)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Positive](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L272)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1436,7 +1436,7 @@ func main() {
 |--|--|
 | [`assertions.PositiveT[SignedNumber SignedNumeric](t T, e SignedNumber, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#PositiveT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#PositiveT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L289)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#PositiveT](https://github.com/go-openapi/testify/blob/master/internal/assertions/compare.go#L294)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/condition.md
+++ b/docs/doc-site/api/condition.md
@@ -449,7 +449,7 @@ func main() {
 |--|--|
 | [`assertions.Consistently[C Conditioner](t T, condition C, timeout time.Duration, tick time.Duration, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Consistently) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Consistently](https://github.com/go-openapi/testify/blob/master/internal/assertions/condition.go#L225)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Consistently](https://github.com/go-openapi/testify/blob/master/internal/assertions/condition.go#L226)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -960,7 +960,7 @@ func main() {
 |--|--|
 | [`assertions.EventuallyWith[C CollectibleConditioner](t T, condition C, timeout time.Duration, tick time.Duration, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#EventuallyWith) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EventuallyWith](https://github.com/go-openapi/testify/blob/master/internal/assertions/condition.go#L294)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EventuallyWith](https://github.com/go-openapi/testify/blob/master/internal/assertions/condition.go#L295)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1187,7 +1187,7 @@ func main() {
 |--|--|
 | [`assertions.Never(t T, condition func() bool, timeout time.Duration, tick time.Duration, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Never) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Never](https://github.com/go-openapi/testify/blob/master/internal/assertions/condition.go#L167)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Never](https://github.com/go-openapi/testify/blob/master/internal/assertions/condition.go#L168)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/equality.md
+++ b/docs/doc-site/api/equality.md
@@ -187,7 +187,7 @@ func main() {
 |--|--|
 | [`assertions.Empty(t T, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Empty) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Empty](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_unary.go#L73)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Empty](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_unary.go#L74)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -434,7 +434,7 @@ type dummyStruct struct {
 |--|--|
 | [`assertions.EqualExportedValues(t T, expected any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#EqualExportedValues) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualExportedValues](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L214)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualExportedValues](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L217)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -548,7 +548,7 @@ func main() {
 |--|--|
 | [`assertions.EqualT[V comparable](t T, expected V, actual V, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#EqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L67)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L68)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -662,7 +662,7 @@ func main() {
 |--|--|
 | [`assertions.EqualValues(t T, expected any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#EqualValues) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualValues](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L142)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualValues](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L144)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -773,7 +773,7 @@ func main() {
 |--|--|
 | [`assertions.Exactly(t T, expected any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Exactly) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Exactly](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L256)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Exactly](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L259)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -997,7 +997,7 @@ func main() {
 |--|--|
 | [`assertions.NotEmpty(t T, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotEmpty) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEmpty](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_unary.go#L98)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEmpty](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_unary.go#L100)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1111,7 +1111,7 @@ func main() {
 |--|--|
 | [`assertions.NotEqual(t T, expected any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotEqual) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEqual](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L91)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEqual](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L93)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1220,7 +1220,7 @@ func main() {
 |--|--|
 | [`assertions.NotEqualT[V comparable](t T, expected V, actual V, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotEqualT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L120)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEqualT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L122)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1333,7 +1333,7 @@ func main() {
 |--|--|
 | [`assertions.NotEqualValues(t T, expected any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotEqualValues) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEqualValues](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L176)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotEqualValues](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal.go#L179)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1444,7 +1444,7 @@ func main() {
 |--|--|
 | [`assertions.NotNil(t T, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotNil) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotNil](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_unary.go#L42)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotNil](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_unary.go#L43)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1575,7 +1575,7 @@ func ptr[T any](value T) *T {
 |--|--|
 | [`assertions.NotSame(t T, expected any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotSame) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSame](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_pointer.go#L84)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSame](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_pointer.go#L86)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1702,7 +1702,7 @@ func ptr[T any](value T) *T {
 |--|--|
 | [`assertions.NotSameT[P any](t T, expected *P, actual *P, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotSameT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSameT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_pointer.go#L116)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSameT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_pointer.go#L118)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1952,7 +1952,7 @@ var (
 |--|--|
 | [`assertions.SameT[P any](t T, expected *P, actual *P, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SameT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SameT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_pointer.go#L57)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SameT](https://github.com/go-openapi/testify/blob/master/internal/assertions/equal_pointer.go#L58)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/error.md
+++ b/docs/doc-site/api/error.md
@@ -154,7 +154,7 @@ func main() {
 |--|--|
 | [`assertions.EqualError(t T, err error, errString string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#EqualError) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualError](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L89)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#EqualError](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L90)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -393,7 +393,7 @@ func (d *dummyError) Error() string {
 |--|--|
 | [`assertions.ErrorAs(t T, err error, target any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#ErrorAs) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ErrorAs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L220)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ErrorAs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L222)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -506,7 +506,7 @@ func main() {
 |--|--|
 | [`assertions.ErrorContains(t T, err error, contains string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#ErrorContains) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ErrorContains](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L120)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ErrorContains](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L121)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -621,7 +621,7 @@ func main() {
 |--|--|
 | [`assertions.ErrorIs(t T, err error, target error, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#ErrorIs) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ErrorIs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L149)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#ErrorIs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L150)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -861,7 +861,7 @@ func (d *dummyError) Error() string {
 |--|--|
 | [`assertions.NotErrorAs(t T, err error, target any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotErrorAs) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotErrorAs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L254)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotErrorAs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L257)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -976,7 +976,7 @@ func main() {
 |--|--|
 | [`assertions.NotErrorIs(t T, err error, target error, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotErrorIs) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotErrorIs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L186)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotErrorIs](https://github.com/go-openapi/testify/blob/master/internal/assertions/error.go#L188)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/file.md
+++ b/docs/doc-site/api/file.md
@@ -157,7 +157,7 @@ func testDataPath() string {
 |--|--|
 | [`assertions.DirExists(t T, path string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#DirExists) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#DirExists](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L81)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#DirExists](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L82)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -279,7 +279,7 @@ func testDataPath() string {
 |--|--|
 | [`assertions.DirNotExists(t T, path string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#DirNotExists) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#DirNotExists](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L110)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#DirNotExists](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L112)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -401,7 +401,7 @@ func testDataPath() string {
 |--|--|
 | [`assertions.FileEmpty(t T, path string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#FileEmpty) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FileEmpty](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L139)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FileEmpty](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L141)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -645,7 +645,7 @@ func testDataPath() string {
 |--|--|
 | [`assertions.FileNotEmpty(t T, path string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#FileNotEmpty) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FileNotEmpty](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L180)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FileNotEmpty](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L183)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -767,7 +767,7 @@ func testDataPath() string {
 |--|--|
 | [`assertions.FileNotExists(t T, path string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#FileNotExists) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FileNotExists](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L52)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#FileNotExists](https://github.com/go-openapi/testify/blob/master/internal/assertions/file.go#L53)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/http.md
+++ b/docs/doc-site/api/http.md
@@ -292,7 +292,7 @@ func httpBody(w http.ResponseWriter, r *http.Request) {
 |--|--|
 | [`assertions.HTTPBodyNotContains(t T, handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#HTTPBodyNotContains) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#HTTPBodyNotContains](https://github.com/go-openapi/testify/blob/master/internal/assertions/http.go#L175)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#HTTPBodyNotContains](https://github.com/go-openapi/testify/blob/master/internal/assertions/http.go#L176)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/metrics.md
+++ b/docs/doc-site/api/metrics.md
@@ -1,0 +1,118 @@
+---
+title: "Quick API index"
+description: |
+  API Quick Index & Metrics.
+weight: -1
+---
+
+## Domains
+
+All assertions are classified into **19** domains to help navigate the API, depending on your use case.
+
+## API metrics
+
+Counts for core functionality, excluding variants (formatted, forward, forward-formatted).
+
+| Kind                     | Count             |
+| ------------------------ | ----------------- |
+| All functions            | 135  |
+| All core assertions      | 131 |
+| Generic assertions       | 49   |
+| Helpers (not assertions) | 4    |
+| Others                   | 0     |
+
+## Quick index
+
+Table of core assertions, excluding variants. Each function is side by side with its logical opposite (when available).
+
+| Assertion                | Opposite          | Domain | Kind |
+| ------------------------ | ----------------- | ------ | ---- |
+| [CallerInfo](common/#callerinfo) |  | common | helper |
+| [Condition](condition/#condition) |  | condition |  |
+| [Consistently[C Conditioner]](condition/#consistentlyc-conditioner) {{% icon icon="star" color=orange %}} |  | condition |  |
+| [Contains](collection/#contains) | [NotContains](collection/#notcontains) | collection |  |
+| [DirExists](file/#direxists) | [DirNotExists](file/#dirnotexists) | file |  |
+| [ElementsMatch](collection/#elementsmatch) | [NotElementsMatch](collection/#notelementsmatch) | collection |  |
+| [ElementsMatchT[E comparable]](collection/#elementsmatchte-comparable) {{% icon icon="star" color=orange %}} | [NotElementsMatchT](collection/#notelementsmatchte-comparable) | collection |  |
+| [Empty](equality/#empty) | [NotEmpty](equality/#notempty) | equality |  |
+| [Equal](equality/#equal) | [NotEqual](equality/#notequal) | equality |  |
+| [EqualError](error/#equalerror) |  | error |  |
+| [EqualExportedValues](equality/#equalexportedvalues) |  | equality |  |
+| [EqualT[V comparable]](equality/#equaltv-comparable) {{% icon icon="star" color=orange %}} | [NotEqualT](equality/#notequaltv-comparable) | equality |  |
+| [EqualValues](equality/#equalvalues) | [NotEqualValues](equality/#notequalvalues) | equality |  |
+| [Error](error/#error) | [NoError](error/#noerror) | error |  |
+| [ErrorAs](error/#erroras) | [NotErrorAs](error/#noterroras) | error |  |
+| [ErrorContains](error/#errorcontains) |  | error |  |
+| [ErrorIs](error/#erroris) | [NotErrorIs](error/#noterroris) | error |  |
+| [EventuallyWith[C CollectibleConditioner]](condition/#eventuallywithc-collectibleconditioner) {{% icon icon="star" color=orange %}} |  | condition |  |
+| [Eventually[C Conditioner]](condition/#eventuallyc-conditioner) {{% icon icon="star" color=orange %}} | [Never](condition/#never) | condition |  |
+| [Exactly](equality/#exactly) |  | equality |  |
+| [Fail](testing/#fail) |  | testing |  |
+| [FailNow](testing/#failnow) |  | testing |  |
+| [FileEmpty](file/#fileempty) | [FileNotEmpty](file/#filenotempty) | file |  |
+| [FileExists](file/#fileexists) | [FileNotExists](file/#filenotexists) | file |  |
+| [Greater](comparison/#greater) | [LessOrEqual](comparison/#lessorequal) | comparison |  |
+| [GreaterOrEqual](comparison/#greaterorequal) | [Less](comparison/#less) | comparison |  |
+| [GreaterOrEqualT[Orderable Ordered]](comparison/#greaterorequaltorderable-ordered) {{% icon icon="star" color=orange %}} | [LessT](comparison/#lesstorderable-ordered) | comparison |  |
+| [GreaterT[Orderable Ordered]](comparison/#greatertorderable-ordered) {{% icon icon="star" color=orange %}} | [LessOrEqualT](comparison/#lessorequaltorderable-ordered) | comparison |  |
+| [HTTPBody](http/#httpbody) |  | http | helper |
+| [HTTPBodyContains](http/#httpbodycontains) | [HTTPBodyNotContains](http/#httpbodynotcontains) | http |  |
+| [HTTPError](http/#httperror) |  | http |  |
+| [HTTPRedirect](http/#httpredirect) |  | http |  |
+| [HTTPStatusCode](http/#httpstatuscode) |  | http |  |
+| [HTTPSuccess](http/#httpsuccess) |  | http |  |
+| [Implements](type/#implements) | [NotImplements](type/#notimplements) | type |  |
+| [InDelta](number/#indelta) |  | number |  |
+| [InDeltaMapValues](number/#indeltamapvalues) |  | number |  |
+| [InDeltaSlice](number/#indeltaslice) |  | number |  |
+| [InDeltaT[Number Measurable]](number/#indeltatnumber-measurable) {{% icon icon="star" color=orange %}} |  | number |  |
+| [InEpsilon](number/#inepsilon) |  | number |  |
+| [InEpsilonSlice](number/#inepsilonslice) |  | number |  |
+| [InEpsilonT[Number Measurable]](number/#inepsilontnumber-measurable) {{% icon icon="star" color=orange %}} |  | number |  |
+| [IsDecreasing](ordering/#isdecreasing) | [IsNonDecreasing](ordering/#isnondecreasing) | ordering |  |
+| [IsDecreasingT[OrderedSlice ~[]E, E Ordered]](ordering/#isdecreasingtorderedslice-e-e-ordered) {{% icon icon="star" color=orange %}} | [IsNonDecreasingT](ordering/#isnondecreasingtorderedslice-e-e-ordered) | ordering |  |
+| [IsIncreasing](ordering/#isincreasing) | [IsNonIncreasing](ordering/#isnonincreasing) | ordering |  |
+| [IsIncreasingT[OrderedSlice ~[]E, E Ordered]](ordering/#isincreasingtorderedslice-e-e-ordered) {{% icon icon="star" color=orange %}} | [IsNonIncreasingT](ordering/#isnonincreasingtorderedslice-e-e-ordered) | ordering |  |
+| [IsOfTypeT[EType any]](type/#isoftypetetype-any) {{% icon icon="star" color=orange %}} | [IsNotOfTypeT](type/#isnotoftypetetype-any) | type |  |
+| [IsType](type/#istype) | [IsNotType](type/#isnottype) | type |  |
+| [JSONEq](json/#jsoneq) |  | json |  |
+| [JSONEqBytes](json/#jsoneqbytes) |  | json |  |
+| [JSONEqT[EDoc, ADoc Text]](json/#jsoneqtedoc-adoc-text) {{% icon icon="star" color=orange %}} |  | json |  |
+| [JSONMarshalAsT[EDoc Text]](json/#jsonmarshalastedoc-text) {{% icon icon="star" color=orange %}} |  | json |  |
+| [JSONUnmarshalAsT[Object any, ADoc Text]](json/#jsonunmarshalastobject-any-adoc-text) {{% icon icon="star" color=orange %}} |  | json |  |
+| [Kind](type/#kind) | [NotKind](type/#notkind) | type |  |
+| [Len](collection/#len) |  | collection |  |
+| [MapContainsT[Map ~map[K]V, K comparable, V any]](collection/#mapcontainstmap-mapkv-k-comparable-v-any) {{% icon icon="star" color=orange %}} | [MapNotContainsT](collection/#mapnotcontainstmap-mapkv-k-comparable-v-any) | collection |  |
+| [MapEqualT[K, V comparable]](collection/#mapequaltk-v-comparable) {{% icon icon="star" color=orange %}} | [MapNotEqualT](collection/#mapnotequaltk-v-comparable) | collection |  |
+| [Nil](equality/#nil) | [NotNil](equality/#notnil) | equality |  |
+| [NoFileDescriptorLeak](safety/#nofiledescriptorleak) |  | safety |  |
+| [NoGoRoutineLeak](safety/#nogoroutineleak) |  | safety |  |
+| [ObjectsAreEqual](common/#objectsareequal) |  | common | helper |
+| [ObjectsAreEqualValues](common/#objectsareequalvalues) |  | common | helper |
+| [Panics](panic/#panics) | [NotPanics](panic/#notpanics) | panic |  |
+| [PanicsWithError](panic/#panicswitherror) |  | panic |  |
+| [PanicsWithValue](panic/#panicswithvalue) |  | panic |  |
+| [Positive](comparison/#positive) | [Negative](comparison/#negative) | comparison |  |
+| [PositiveT[SignedNumber SignedNumeric]](comparison/#positivetsignednumber-signednumeric) {{% icon icon="star" color=orange %}} | [NegativeT](comparison/#negativetsignednumber-signednumeric) | comparison |  |
+| [Regexp](string/#regexp) | [NotRegexp](string/#notregexp) | string |  |
+| [RegexpT[Rex RegExp, ADoc Text]](string/#regexptrex-regexp-adoc-text) {{% icon icon="star" color=orange %}} | [NotRegexpT](string/#notregexptrex-regexp-adoc-text) | string |  |
+| [Same](equality/#same) | [NotSame](equality/#notsame) | equality |  |
+| [SameT[P any]](equality/#sametp-any) {{% icon icon="star" color=orange %}} | [NotSameT](equality/#notsametp-any) | equality |  |
+| [SeqContainsT[E comparable]](collection/#seqcontainste-comparable) {{% icon icon="star" color=orange %}} | [SeqNotContainsT](collection/#seqnotcontainste-comparable) | collection |  |
+| [SliceContainsT[Slice ~[]E, E comparable]](collection/#slicecontainstslice-e-e-comparable) {{% icon icon="star" color=orange %}} | [SliceNotContainsT](collection/#slicenotcontainstslice-e-e-comparable) | collection |  |
+| [SliceEqualT[E comparable]](collection/#sliceequalte-comparable) {{% icon icon="star" color=orange %}} | [SliceNotEqualT](collection/#slicenotequalte-comparable) | collection |  |
+| [SliceSubsetT[Slice ~[]E, E comparable]](collection/#slicesubsettslice-e-e-comparable) {{% icon icon="star" color=orange %}} | [SliceNotSubsetT](collection/#slicenotsubsettslice-e-e-comparable) | collection |  |
+| [SortedT[OrderedSlice ~[]E, E Ordered]](ordering/#sortedtorderedslice-e-e-ordered) {{% icon icon="star" color=orange %}} | [NotSortedT](ordering/#notsortedtorderedslice-e-e-ordered) | ordering |  |
+| [StringContainsT[ADoc, EDoc Text]](collection/#stringcontainstadoc-edoc-text) {{% icon icon="star" color=orange %}} | [StringNotContainsT](collection/#stringnotcontainstadoc-edoc-text) | collection |  |
+| [Subset](collection/#subset) | [NotSubset](collection/#notsubset) | collection |  |
+| [True](boolean/#true) | [False](boolean/#false) | boolean |  |
+| [TrueT[B Boolean]](boolean/#truetb-boolean) {{% icon icon="star" color=orange %}} | [FalseT](boolean/#falsetb-boolean) | boolean |  |
+| [WithinDuration](time/#withinduration) |  | time |  |
+| [WithinRange](time/#withinrange) |  | time |  |
+| [YAMLEq](yaml/#yamleq) |  | yaml |  |
+| [YAMLEqBytes](yaml/#yamleqbytes) |  | yaml |  |
+| [YAMLEqT[EDoc, ADoc Text]](yaml/#yamleqtedoc-adoc-text) {{% icon icon="star" color=orange %}} |  | yaml |  |
+| [YAMLMarshalAsT[EDoc Text]](yaml/#yamlmarshalastedoc-text) {{% icon icon="star" color=orange %}} |  | yaml |  |
+| [YAMLUnmarshalAsT[Object any, ADoc Text]](yaml/#yamlunmarshalastobject-any-adoc-text) {{% icon icon="star" color=orange %}} |  | yaml |  |
+| [Zero](type/#zero) | [NotZero](type/#notzero) | type |  |
+

--- a/docs/doc-site/api/ordering.md
+++ b/docs/doc-site/api/ordering.md
@@ -161,7 +161,7 @@ func main() {
 |--|--|
 | [`assertions.IsDecreasing(t T, collection any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsDecreasing) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsDecreasing](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L190)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsDecreasing](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L205)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -270,7 +270,7 @@ func main() {
 |--|--|
 | [`assertions.IsDecreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsDecreasingT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsDecreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L220)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsDecreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L236)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -492,12 +492,18 @@ func main() {
 |--|--|
 | [`assertions.IsIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsIncreasingT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsIncreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L53)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsIncreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L54)
 {{% /tab %}}
 {{< /tabs >}}
 
 ### IsNonDecreasing{#isnondecreasing}
 IsNonDecreasing asserts that the collection is not strictly decreasing.
+
+This is the logical negation of [IsDecreasing](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsDecreasing): it succeeds whenever
+[IsDecreasing](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsDecreasing) would fail, including for sequences that are neither
+increasing nor decreasing (e.g. [3, 1, 2]).
+
+It is NOT the same as "weakly increasing" (a[i](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#i) <= a[i+1] for all i).
 
 {{% expand title="Examples" %}}
 {{< tabs >}}
@@ -605,12 +611,18 @@ func main() {
 |--|--|
 | [`assertions.IsNonDecreasing(t T, collection any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsNonDecreasing) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonDecreasing](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L246)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonDecreasing](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L269)
 {{% /tab %}}
 {{< /tabs >}}
 
 ### IsNonDecreasingT[OrderedSlice ~[]E, E Ordered] {{% icon icon="star" color=orange %}}{#isnondecreasingtorderedslice-e-e-ordered}
-IsNonDecreasingT asserts that a slice of [Ordered](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#Ordered) is not decreasing.
+IsNonDecreasingT asserts that a slice of [Ordered](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#Ordered) is NOT strictly decreasing.
+
+This is the logical negation of [IsDecreasingT](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsDecreasingT): it succeeds whenever
+[IsDecreasingT](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsDecreasingT) would fail, including for sequences that are neither
+increasing nor decreasing (e.g. [3, 1, 2]).
+
+It is NOT the same as "weakly increasing" (a[i](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#i) <= a[i+1] for all i).
 
 {{% expand title="Examples" %}}
 {{< tabs >}}
@@ -714,12 +726,18 @@ func main() {
 |--|--|
 | [`assertions.IsNonDecreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsNonDecreasingT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonDecreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L275)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonDecreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L304)
 {{% /tab %}}
 {{< /tabs >}}
 
 ### IsNonIncreasing{#isnonincreasing}
-IsNonIncreasing asserts that the collection is not increasing.
+IsNonIncreasing asserts that the collection is not strictly increasing.
+
+This is the logical negation of [IsIncreasing](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsIncreasing): it succeeds whenever
+[IsIncreasing](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsIncreasing) would fail, including for sequences that are neither
+increasing nor decreasing (e.g. [1, 3, 2]).
+
+It is NOT the same as "weakly decreasing" (a[i](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#i) >= a[i+1] for all i).
 
 {{% expand title="Examples" %}}
 {{< tabs >}}
@@ -827,20 +845,26 @@ func main() {
 |--|--|
 | [`assertions.IsNonIncreasing(t T, collection any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsNonIncreasing) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonIncreasing](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L135)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonIncreasing](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L144)
 {{% /tab %}}
 {{< /tabs >}}
 
 ### IsNonIncreasingT[OrderedSlice ~[]E, E Ordered] {{% icon icon="star" color=orange %}}{#isnonincreasingtorderedslice-e-e-ordered}
 IsNonIncreasingT asserts that a slice of [Ordered](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#Ordered) is NOT strictly increasing.
 
+This is the logical negation of [IsIncreasingT](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsIncreasingT): it succeeds whenever
+[IsIncreasingT](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#IsIncreasingT) would fail, including for sequences that are neither
+increasing nor decreasing (e.g. [1, 3, 2]).
+
+It is NOT the same as "weakly decreasing" (a[i](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#i) >= a[i+1] for all i).
+
 {{% expand title="Examples" %}}
 {{< tabs >}}
 {{% tab title="Usage" %}}
 ```go
-	assertions.IsNonIncreasing(t, []int{2, 1, 1})
-	assertions.IsNonIncreasing(t, []float{2, 1})
-	assertions.IsNonIncreasing(t, []string{"b", "a"})
+	assertions.IsNonIncreasingT(t, []int{2, 1, 1})
+	assertions.IsNonIncreasingT(t, []float{2, 1})
+	assertions.IsNonIncreasingT(t, []string{"b", "a"})
 	success: []int{2, 1, 1}
 	failure: []int{1, 2, 3}
 ```
@@ -936,7 +960,7 @@ func main() {
 |--|--|
 | [`assertions.IsNonIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsNonIncreasingT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonIncreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L164)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNonIncreasingT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L179)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1047,7 +1071,7 @@ func main() {
 |--|--|
 | [`assertions.NotSortedT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotSortedT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSortedT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L109)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotSortedT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L112)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1158,7 +1182,7 @@ func main() {
 |--|--|
 | [`assertions.SortedT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#SortedT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SortedT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L81)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#SortedT](https://github.com/go-openapi/testify/blob/master/internal/assertions/order.go#L83)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/panic.md
+++ b/docs/doc-site/api/panic.md
@@ -142,7 +142,7 @@ func main() {
 |--|--|
 | [`assertions.NotPanics(t T, f func(), msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotPanics) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotPanics](https://github.com/go-openapi/testify/blob/master/internal/assertions/panic.go#L111)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotPanics](https://github.com/go-openapi/testify/blob/master/internal/assertions/panic.go#L112)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -374,7 +374,7 @@ func main() {
 |--|--|
 | [`assertions.PanicsWithError(t T, errString string, f func(), msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#PanicsWithError) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#PanicsWithError](https://github.com/go-openapi/testify/blob/master/internal/assertions/panic.go#L77)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#PanicsWithError](https://github.com/go-openapi/testify/blob/master/internal/assertions/panic.go#L78)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -490,7 +490,7 @@ func main() {
 |--|--|
 | [`assertions.PanicsWithValue(t T, expected any, f func(), msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#PanicsWithValue) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#PanicsWithValue](https://github.com/go-openapi/testify/blob/master/internal/assertions/panic.go#L49)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#PanicsWithValue](https://github.com/go-openapi/testify/blob/master/internal/assertions/panic.go#L50)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/string.md
+++ b/docs/doc-site/api/string.md
@@ -144,7 +144,7 @@ func main() {
 |--|--|
 | [`assertions.NotRegexp(t T, rx any, actual any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotRegexp) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotRegexp](https://github.com/go-openapi/testify/blob/master/internal/assertions/string.go#L90)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotRegexp](https://github.com/go-openapi/testify/blob/master/internal/assertions/string.go#L92)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -254,7 +254,7 @@ func main() {
 |--|--|
 | [`assertions.NotRegexpT[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotRegexpT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotRegexpT](https://github.com/go-openapi/testify/blob/master/internal/assertions/string.go#L131)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotRegexpT](https://github.com/go-openapi/testify/blob/master/internal/assertions/string.go#L133)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -476,7 +476,7 @@ func main() {
 |--|--|
 | [`assertions.RegexpT[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#RegexpT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#RegexpT](https://github.com/go-openapi/testify/blob/master/internal/assertions/string.go#L63)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#RegexpT](https://github.com/go-openapi/testify/blob/master/internal/assertions/string.go#L64)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/type.md
+++ b/docs/doc-site/api/type.md
@@ -296,7 +296,7 @@ type myType float64
 |--|--|
 | [`assertions.IsNotOfTypeT[EType any](t T, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsNotOfTypeT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNotOfTypeT](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L141)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNotOfTypeT](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L144)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -407,7 +407,7 @@ func main() {
 |--|--|
 | [`assertions.IsNotType(t T, theType any, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsNotType) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNotType](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L120)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsNotType](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L123)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -518,7 +518,7 @@ type myType float64
 |--|--|
 | [`assertions.IsOfTypeT[EType any](t T, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsOfTypeT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsOfTypeT](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L96)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsOfTypeT](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L98)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -629,7 +629,7 @@ func main() {
 |--|--|
 | [`assertions.IsType(t T, expectedType any, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#IsType) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsType](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L75)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#IsType](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L76)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -745,7 +745,7 @@ func main() {
 |--|--|
 | [`assertions.Kind(t T, expectedKind reflect.Kind, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Kind) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Kind](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L210)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Kind](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L214)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -856,7 +856,7 @@ func main() {
 |--|--|
 | [`assertions.NotImplements(t T, interfaceObject any, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotImplements) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotImplements](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L48)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotImplements](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L49)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -972,7 +972,7 @@ func main() {
 |--|--|
 | [`assertions.NotKind(t T, expectedKind reflect.Kind, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotKind) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotKind](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L243)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotKind](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L248)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1083,7 +1083,7 @@ func main() {
 |--|--|
 | [`assertions.NotZero(t T, i any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#NotZero) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotZero](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L186)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#NotZero](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L190)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1194,7 +1194,7 @@ func main() {
 |--|--|
 | [`assertions.Zero(t T, i any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#Zero) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Zero](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L165)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#Zero](https://github.com/go-openapi/testify/blob/master/internal/assertions/type.go#L168)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/project/APPROACH.md
+++ b/docs/doc-site/project/APPROACH.md
@@ -443,7 +443,7 @@ question for Go developers is: **which style aligns with the values that drew yo
 
 ## See also
 
-- [API Reference](../api/) - Browse all 120 assertions by domain
+- [API Reference](../api/) - Browse all {{% siteparam "metrics.assertions" %}} assertions by domain
 - [Generics Guide](../usage/GENERICS.md) - Leverage type-safe assertions
 - [Migration Guide](../usage/MIGRATION.md) - Switch from stretchr/testify
 - [Examples](../usage/EXAMPLES.md) - See testify in action

--- a/docs/doc-site/project/README.md
+++ b/docs/doc-site/project/README.md
@@ -17,7 +17,7 @@ weight: 2
 * 95% compatible with `stretchr/testify` — if you already use it, our migration tool automates the switch
 * Actively maintained: regular fixes and evolutions, many PRs proposed upstream are already in
 * Zero external dependencies — you import what you need, with opt-in modules for extras (e.g. YAML, colorized output)
-* Modernized codebase targeting go1.24+
+* Modernized codebase targeting go1.25+
 * Go routine leak detection built in: zero-setup, no false positives, works with parallel tests (unlike `go.uber.org/goleak`)
 * File descriptor leak detection (linux-only)
 * Type-safe assertions with generics (see [a basic example](../usage/EXAMPLES.md)) — migration to generics can be automated too. [Read the full story](../usage/GENERICS.md)
@@ -28,7 +28,7 @@ weight: 2
 ### This fork isn't for everyone
 
 * You need the `mock` package — we removed it and won't bring it back. For suites, we're [open to discussion](https://github.com/go-openapi/testify/discussions/75) about a redesigned approach
-* Your project must support Go versions older than 1.24
+* Your project must support Go versions older than 1.25
 * You rely on `testifylint` or other tooling that expects the `stretchr/testify` import path
 * You need 100% API compatibility — we're at 95%, and the remaining 5% are intentional removals
 
@@ -38,7 +38,7 @@ See [why we wanted a v2](./MOTIVATION.md).
 
 ### Approach with this fork
 
-This fork targets **go1.24**.
+This fork targets **go1.25**.
 
 * [x] **zero** external dependencies by default
 * [x] extra features (and dependencies) are opt-in

--- a/docs/doc-site/project/maintainers/ARCHITECTURE.md
+++ b/docs/doc-site/project/maintainers/ARCHITECTURE.md
@@ -57,20 +57,20 @@ We have adopted code and documentation generation as a mean to mitigate this iss
 
 #### Current (v2.3.0-unreleased)
 
- 1. Generic assertions (with type parameters): 46 functions
- 2. Non-generic assertions (with t T parameter, no type parameters): 82 functions
- 3. Helper functions (no t T parameter): 4 functions
+ 1. Generic assertions (with type parameters): {{% siteparam "metrics.generics" %}} functions
+ 2. Non-generic assertions (with t T parameter, no type parameters): {{% siteparam "metrics.nongeneric_assertions" %}} functions
+ 3. Helper functions (no t T parameter): {{% siteparam "metrics.helpers" %}} functions
 
- Total: 128 functions to _maintain_
+ Total: {{% siteparam "metrics.functions" %}} functions to _maintain_
 
  **Generated Functions**
 
- 1. Generic assertions: 168
- 2. Non-generic assertions: 656
- 3. Helper functions: 8
+ 1. Generic assertions: {{% siteparam "metrics.generated_generic" %}}
+ 2. Non-generic assertions: {{% siteparam "metrics.generated_nongeneric" %}}
+ 3. Helper functions: {{% siteparam "metrics.generated_helpers" %}}
  4. Constructors: 2
 
- Total: 834 functions
+ Total: {{% siteparam "metrics.generated_total" %}} functions
 
 ## Architecture Overview
 

--- a/docs/doc-site/project/maintainers/BENCHMARKS.md
+++ b/docs/doc-site/project/maintainers/BENCHMARKS.md
@@ -158,7 +158,7 @@ go test -run=^$ -bench=. -benchmem ./internal/assertions
 
 ## Benchmark Coverage
 
-**38/46 generic functions benchmarked across 10 domains:**
+**38/{{% siteparam "metrics.generics" %}} generic functions benchmarked across 10 domains:**
 - Boolean (2): TrueT, FalseT
 - Collection (16): StringContainsT, SliceContainsT, MapContainsT, SeqContainsT, ElementsMatchT, SliceSubsetT, SliceEqualT, MapEqualT, and negative variants
 - Comparison (6): GreaterT, LessT, GreaterOrEqualT, LessOrEqualT, PositiveT, NegativeT

--- a/docs/doc-site/project/maintainers/ROADMAP.md
+++ b/docs/doc-site/project/maintainers/ROADMAP.md
@@ -20,6 +20,7 @@ timeline
                     : documentation site
                     : panic handling fixes
                     : removed deprecated
+                    : go1.24+
     ✅ v2.2 (Fev 2026) : Generics
                     : Kind/NotKind
                     : SortedT, NotSortedT
@@ -40,6 +41,7 @@ timeline
                     : NoFileDescriptorLeak (macOS, Windows)
                     : New candidate features from upstream
                     : export internal tools (spew, difflib)
+                    : go1.25+
 {{< /mermaid >}}
 
 ## Notes

--- a/docs/doc-site/usage/CHANGES.md
+++ b/docs/doc-site/usage/CHANGES.md
@@ -10,7 +10,7 @@ weight: 15
 - ✅ **Zero Dependencies**: Completely self-contained
 - ✅ **New functions**: 58 additional assertions (43 generic + 15 reflection-based)
 - ✅ **Performance**: ~10x for generic variants (from 1.2x to 81x, your mileage may vary)
-- ✅ **Breaking changes**: Requires go1.24, removed suites, mocks, http tooling, and deprecated functions. YAMLEq becomes optional (panics by default).
+- ✅ **Breaking changes**: Requires go1.25, removed suites, mocks, http tooling, and deprecated functions. YAMLEq becomes optional (panics by default).
 
 ---
 
@@ -54,7 +54,7 @@ See also a quick [migration guide](./MIGRATION.md).
 
 | Change | Origin | Description |
 |--------|--------|-------------|
-| **Code generation** | Design goal | 100% generated assert/require packages (840 functions from 127 assertions) |
+| **Code generation** | Design goal | 100% generated assert/require packages from {{% siteparam "metrics.functions" %}} core functions (see [API metrics](../api/metrics.md)) |
 | **Code modernization** | Design goal | Relinted, refactored and modernized the code base, including internalized difflib and go-spew|
 | **Refactored tests** | Design goal | Full refactoring of tests on assertion functions, with unified test scenarios for reflection-based/generic assertions |
 
@@ -571,7 +571,7 @@ github.com/go-openapi/testify/v2           # Core (zero deps) [go.mod]
 ### Documentation
 
 - Hugo-based documentation site
-- Domain-organized API reference (19 domains)
+- Domain-organized API reference ({{% siteparam "metrics.domains" %}} domains)
 - Comprehensive examples and tutorials
 - Performance benchmarks
 
@@ -579,21 +579,20 @@ github.com/go-openapi/testify/v2           # Core (zero deps) [go.mod]
 
 | Metric | Value |
 |--------|-------|
-| **New functions** | 58 (43 generic + 15 reflection) |
-| **Total assertions** | 127 base assertions |
-| **Generated functions** | 840 (see [the maths](../project/maintainers/ARCHITECTURE.md#the-maths-with-assertion-variants)) |
-| **Generic coverage** | 10 domains (10/19) |
+| **Total functions** | {{% siteparam "metrics.functions" %}} (see [API metrics](../api/metrics.md)) |
+| **Total assertions** | {{% siteparam "metrics.assertions" %}} base assertions |
+| **Generic assertions** | {{% siteparam "metrics.generics" %}} |
 | **Performance improvement** | 1.2x to 81x faster |
 | **Dependencies** | 0 external (was 2 required) |
 | **Test coverage** | 96% overall, 99% on public APIs |
-| **Documentation domains** | 19 logical categories |
+| **Documentation domains** | {{% siteparam "metrics.domains" %}} logical categories |
 
 ---
 
 ## See Also
 
 - [Migration Guide](./MIGRATION.md) - Step-by-step guide to migrating from testify v1
-- [Generics Guide](./GENERICS.md) - Detailed documentation of all 43 generic assertions
+- [Generics Guide](./GENERICS.md) - Detailed documentation of all {{% siteparam "metrics.generics" %}} generic assertions
 - [Performance Benchmarks](../project/maintainers/BENCHMARKS.md) - Comprehensive performance analysis
 - [Examples](./EXAMPLES.md) - Practical usage examples showing new features
 - [Tutorial](./TUTORIAL.md) - Best practices for writing tests with testify v2

--- a/docs/doc-site/usage/GENERICS.md
+++ b/docs/doc-site/usage/GENERICS.md
@@ -4,7 +4,7 @@ description: Using generic assertions.
 weight: 10
 ---
 
-Testify v2 provides **46 generic assertion functions** that offer compile-time type safety alongside
+Testify v2 provides **{{% siteparam "metrics.generics" %}} generic assertion functions** that offer compile-time type safety alongside
 the traditional reflection-based assertions. Generic variants are identified by the `T` suffix
 (e.g., `EqualT`, `GreaterT`, `ElementsMatchT`).
 

--- a/docs/doc-site/usage/TRACKING.md
+++ b/docs/doc-site/usage/TRACKING.md
@@ -119,7 +119,7 @@ This table catalogs all upstream PRs and issues from [github.com/stretchr/testif
 
 | Reference | Type | Summary | Outcome |
 |-----------|------|---------|---------|
-| [#1147] | Issue | General discussion about generics adoption | ℹ️ Marked "Not Planned" upstream - We implemented our own generics approach (46 functions) |
+| [#1147] | Issue | General discussion about generics adoption | ℹ️ Marked "Not Planned" upstream - We implemented our own generics approach ({{% siteparam "metrics.generics" %}} functions) |
 | [#1308] | PR | Comprehensive refactor with generic type parameters | ℹ️ Draft for v2.0.0 upstream - We took a different approach with the same objective |
 
 [#1147]: https://github.com/stretchr/testify/issues/1147

--- a/docs/doc-site/usage/USAGE.md
+++ b/docs/doc-site/usage/USAGE.md
@@ -6,10 +6,10 @@ weight: 1
 
 {{% notice primary "TL;DR" "meteor" %}}
 > Learn testify's naming conventions (assert vs require, format variants, generic `T` suffix), argument order patterns, and how to navigate
-> 76+ assertions organized into 18 domains. Start here to understand the API structure.
+> {{% siteparam "metrics.assertions" %}} assertions organized into {{% siteparam "metrics.domains" %}} domains. Start here to understand the API structure.
 {{% /notice %}}
 
-Testify v2 provides **over 40 core assertion types** (76+ functions including inverse variants and all naming styles) organized into clear domains. This guide explains how to navigate the API and use the naming conventions effectively.
+Testify v2 provides **{{% siteparam "metrics.functions" %}} functions** ({{% siteparam "metrics.assertions" %}} assertions including {{% siteparam "metrics.generics" %}} generic variants, plus {{% siteparam "metrics.helpers" %}} helper functions) organized into {{% siteparam "metrics.domains" %}} domains. This guide explains how to navigate the API and use the naming conventions effectively.
 
 ## How the API is Organized
 
@@ -17,17 +17,24 @@ Assertions are grouped by domain for easier discovery:
 
 | Domain | Examples | Count |
 |--------|----------|-------|
-| **Boolean** | `True`, `False` | 2 |
-| **Equality** | `Equal`, `NotEqual`, `EqualValues`, `Same`, `Exactly` | 8 |
-| **Comparison** | `Greater`, `Less`, `Positive` | 8 |
-| **Collection** | `Contains`, `Len`, `Empty`, `ElementsMatch` | 18 |
-| **Error** | `Error`, `NoError`, `ErrorIs`, `ErrorAs`, `ErrorContains` | 8 |
-| **Type** | `IsType`, `Implements`, `Zero` | 7 |
-| **String** | `Regexp`, `NotRegexp` | 4 |
-| **Numeric** | `InDelta`, `InEpsilon` | 6 |
-| **Ordering** | `IsIncreasing`, `Sorted` | 8 |
-| **Panic** | `Panics`, `NotPanics` | 4 |
-| **Others** | HTTP, JSON, YAML, Time, File assertions | 12 |
+| **Boolean** | `True`, `False` | {{% siteparam "metrics.by_domain.boolean.count" %}} |
+| **Collection** | `Contains`, `Len`, `Empty`, `ElementsMatch` | {{% siteparam "metrics.by_domain.collection.count" %}} |
+| **Comparison** | `Greater`, `Less`, `Positive` | {{% siteparam "metrics.by_domain.comparison.count" %}} |
+| **Condition** | `Eventually`, `Never`, `Consistently` | {{% siteparam "metrics.by_domain.condition.count" %}} |
+| **Equality** | `Equal`, `NotEqual`, `EqualValues`, `Same`, `Exactly` | {{% siteparam "metrics.by_domain.equality.count" %}} |
+| **Error** | `Error`, `NoError`, `ErrorIs`, `ErrorAs`, `ErrorContains` | {{% siteparam "metrics.by_domain.error.count" %}} |
+| **File** | `FileExists`, `DirExists`, `FileEmpty` | {{% siteparam "metrics.by_domain.file.count" %}} |
+| **HTTP** | `HTTPSuccess`, `HTTPRedirect`, `HTTPError` | {{% siteparam "metrics.by_domain.http.count" %}} |
+| **JSON** | `JSONEq`, `JSONEqBytes`, `JSONMarshalAs` | {{% siteparam "metrics.by_domain.json.count" %}} |
+| **Number** | `InDelta`, `InEpsilon` | {{% siteparam "metrics.by_domain.number.count" %}} |
+| **Ordering** | `IsIncreasing`, `Sorted` | {{% siteparam "metrics.by_domain.ordering.count" %}} |
+| **Panic** | `Panics`, `NotPanics` | {{% siteparam "metrics.by_domain.panic.count" %}} |
+| **Safety** | `NoGoRoutineLeak`, `NoFileDescriptorLeak` | {{% siteparam "metrics.by_domain.safety.count" %}} |
+| **String** | `Regexp`, `NotRegexp` | {{% siteparam "metrics.by_domain.string.count" %}} |
+| **Testing** | `CallerInfo`, `FailNow` | {{% siteparam "metrics.by_domain.testing.count" %}} |
+| **Time** | `WithinDuration`, `WithinRange` | {{% siteparam "metrics.by_domain.time.count" %}} |
+| **Type** | `IsType`, `Implements`, `Zero` | {{% siteparam "metrics.by_domain.type.count" %}} |
+| **YAML** | `YAMLEq`, `YAMLEqBytes`, `YAMLMarshalAs` | {{% siteparam "metrics.by_domain.yaml.count" %}} |
 
 {{% notice style="info" title="Browse by Domain" icon="book" %}}
 See the complete [API Reference](../api/_index.md) organized by domain for a detailed documentation of all assertions.

--- a/hack/doc-site/hugo/gendoc.go
+++ b/hack/doc-site/hugo/gendoc.go
@@ -69,7 +69,7 @@ func main() {
 
 	// Start Hugo server with both configs.
 	cmd := exec.CommandContext(ctx, "hugo", "server",
-		"--config", "hugo.yaml,testify.yaml",
+		"--config", "hugo.yaml,testify.yaml,metrics.yaml",
 		"--buildDrafts",
 		"--disableFastRender",
 		"--navigateToChanged",

--- a/hack/doc-site/hugo/hugo.yaml
+++ b/hack/doc-site/hugo/hugo.yaml
@@ -117,6 +117,15 @@ params:
     versionMessage: ''
     buildTime: ''
 
+  # Generated metrics (populated by metrics.yaml)
+  metrics:
+    domains: 0
+    functions: 0
+    assertions: 0
+    generics: 0
+    helpers: 0
+    others: 0
+
 # Menu configuration
 menu:
   shortcuts:

--- a/hack/doc-site/hugo/metrics.yaml
+++ b/hack/doc-site/hugo/metrics.yaml
@@ -1,0 +1,67 @@
+params:
+    metrics:
+        domains: 19
+        functions: 135
+        assertions: 131
+        generics: 49
+        nongeneric_assertions: 86
+        helpers: 4
+        others: 0
+        by_domain:
+            boolean:
+                name: Boolean
+                count: 4
+            collection:
+                name: Collection
+                count: 23
+            common:
+                name: Common
+                count: 0
+            comparison:
+                name: Comparison
+                count: 12
+            condition:
+                name: Condition
+                count: 5
+            equality:
+                name: Equality
+                count: 16
+            error:
+                name: Error
+                count: 8
+            file:
+                name: File
+                count: 6
+            http:
+                name: Http
+                count: 6
+            json:
+                name: Json
+                count: 5
+            number:
+                name: Number
+                count: 7
+            ordering:
+                name: Ordering
+                count: 10
+            panic:
+                name: Panic
+                count: 4
+            safety:
+                name: Safety
+                count: 2
+            string:
+                name: String
+                count: 4
+            testing:
+                name: Testing
+                count: 2
+            time:
+                name: Time
+                count: 2
+            type:
+                name: Type
+                count: 10
+            yaml:
+                name: Yaml
+                count: 5

--- a/internal/assertions/boolean.go
+++ b/internal/assertions/boolean.go
@@ -15,6 +15,7 @@ package assertions
 //	failure: 1 == 0
 func True(t T, value bool, msgAndArgs ...any) bool {
 	// Domain: boolean
+	// Opposite: False
 	if !value {
 		if h, ok := t.(H); ok {
 			h.Helper()
@@ -42,6 +43,7 @@ func True(t T, value bool, msgAndArgs ...any) bool {
 //	failure: 1 == 0
 func TrueT[B Boolean](t T, value B, msgAndArgs ...any) bool {
 	// Domain: boolean
+	// Opposite: FalseT
 	if !bool(value) {
 		if h, ok := t.(H); ok {
 			h.Helper()

--- a/internal/assertions/collection.go
+++ b/internal/assertions/collection.go
@@ -63,6 +63,7 @@ func Len(t T, object any, length int, msgAndArgs ...any) bool {
 //	failure: []string{"A","B"}, "C"
 func Contains(t T, s, contains any, msgAndArgs ...any) bool {
 	// Domain: collection
+	// Opposite: NotContains
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -92,6 +93,7 @@ func Contains(t T, s, contains any, msgAndArgs ...any) bool {
 //	failure: "AB", "C"
 func StringContainsT[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msgAndArgs ...any) bool {
 	// Domain: collection
+	// Opposite: StringNotContainsT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -119,6 +121,7 @@ func StringContainsT[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msgAndArgs 
 // [comparable-types]: https://go.dev/blog/comparable
 func SliceContainsT[Slice ~[]E, E comparable](t T, s Slice, element E, msgAndArgs ...any) bool {
 	// Domain: collection
+	// Opposite: SliceNotContainsT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -148,6 +151,7 @@ func SliceContainsT[Slice ~[]E, E comparable](t T, s Slice, element E, msgAndArg
 // [comparable-types]: https://go.dev/blog/comparable
 func SeqContainsT[E comparable](t T, iter iter.Seq[E], element E, msgAndArgs ...any) bool {
 	// Domain: collection
+	// Opposite: SeqNotContainsT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -177,6 +181,7 @@ func SeqContainsT[E comparable](t T, iter iter.Seq[E], element E, msgAndArgs ...
 // [comparable-types]: https://go.dev/blog/comparable
 func MapContainsT[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msgAndArgs ...any) bool {
 	// Domain: collection
+	// Opposite: MapNotContainsT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -343,6 +348,7 @@ const unsupportedCollectionType = "%q has an unsupported type %s"
 //	failure: []int{1, 2, 3}, []int{4, 5}
 func Subset(t T, list, subset any, msgAndArgs ...any) (ok bool) {
 	// Domain: collection
+	// Opposite: NotSubset
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -413,6 +419,7 @@ func Subset(t T, list, subset any, msgAndArgs ...any) (ok bool) {
 //	failure: []int{1, 2, 3}, []int{4, 5}
 func SliceSubsetT[Slice ~[]E, E comparable](t T, list, subset Slice, msgAndArgs ...any) (ok bool) {
 	// Domain: collection
+	// Opposite: SliceNotSubsetT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -538,6 +545,7 @@ func SliceNotSubsetT[Slice ~[]E, E comparable](t T, list, subset Slice, msgAndAr
 //	failure: []int{1, 2, 3}, []int{1, 2, 4}
 func ElementsMatch(t T, listA, listB any, msgAndArgs ...any) (ok bool) {
 	// Domain: collection
+	// Opposite: NotElementsMatch
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -611,6 +619,7 @@ func NotElementsMatch(t T, listA, listB any, msgAndArgs ...any) (ok bool) {
 //	failure: []int{1, 2, 3}, []int{1, 2, 4}
 func ElementsMatchT[E comparable](t T, listA, listB []E, msgAndArgs ...any) bool {
 	// Domain: collection
+	// Opposite: NotElementsMatchT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -683,6 +692,7 @@ func NotElementsMatchT[E comparable](t T, listA, listB []E, msgAndArgs ...any) (
 // [comparable-types]: https://go.dev/blog/comparable
 func SliceEqualT[E comparable](t T, listA, listB []E, msgAndArgs ...any) (ok bool) {
 	// Domain: collection
+	// Opposite: SliceNotEqualT
 	ok = slices.Equal(listA, listB)
 	if !ok {
 		return Fail(t, "listA and listB are not equal", msgAndArgs)
@@ -732,6 +742,7 @@ func SliceNotEqualT[E comparable](t T, listA, listB []E, msgAndArgs ...any) (ok 
 // [comparable-types]: https://go.dev/blog/comparable
 func MapEqualT[K, V comparable](t T, listA, listB map[K]V, msgAndArgs ...any) (ok bool) {
 	// Domain: collection
+	// Opposite: MapNotEqualT
 	ok = maps.Equal(listA, listB)
 	if !ok {
 		return Fail(t, "listA and listB are not equal", msgAndArgs)

--- a/internal/assertions/compare.go
+++ b/internal/assertions/compare.go
@@ -29,6 +29,7 @@ import (
 //	failure: 1, 2
 func Greater(t T, e1 any, e2 any, msgAndArgs ...any) bool {
 	// Domain: comparison
+	// Opposite: LessOrEqual
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -61,6 +62,7 @@ func Greater(t T, e1 any, e2 any, msgAndArgs ...any) bool {
 //	failure: 1, 2
 func GreaterT[Orderable Ordered](t T, e1, e2 Orderable, msgAndArgs ...any) bool {
 	// Domain: comparison
+	// Opposite: LessOrEqualT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -90,6 +92,7 @@ func GreaterT[Orderable Ordered](t T, e1, e2 Orderable, msgAndArgs ...any) bool 
 //	failure: 1, 2
 func GreaterOrEqual(t T, e1 any, e2 any, msgAndArgs ...any) bool {
 	// Domain: comparison
+	// Opposite: Less
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -123,6 +126,7 @@ func GreaterOrEqual(t T, e1 any, e2 any, msgAndArgs ...any) bool {
 //	failure: 1, 2
 func GreaterOrEqualT[Orderable Ordered](t T, e1, e2 Orderable, msgAndArgs ...any) bool {
 	// Domain: comparison
+	// Opposite: LessT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -267,6 +271,7 @@ func LessOrEqualT[Orderable Ordered](t T, e1, e2 Orderable, msgAndArgs ...any) b
 //	failure: -1
 func Positive(t T, e any, msgAndArgs ...any) bool {
 	// Domain: comparison
+	// Opposite: Negative
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -288,6 +293,7 @@ func Positive(t T, e any, msgAndArgs ...any) bool {
 //	failure: -1
 func PositiveT[SignedNumber SignedNumeric](t T, e SignedNumber, msgAndArgs ...any) bool {
 	// Domain: comparison
+	// Opposite: NegativeT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/condition.go
+++ b/internal/assertions/condition.go
@@ -118,6 +118,7 @@ func Condition(t T, comp func() bool, msgAndArgs ...any) bool {
 //	failure:  func() bool { return false }, 100*time.Millisecond, 20*time.Millisecond
 func Eventually[C Conditioner](t T, condition C, timeout time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	// Domain: condition
+	// Opposite: Never
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/equal.go
+++ b/internal/assertions/equal.go
@@ -29,6 +29,7 @@ import (
 //	failure: 123, 456
 func Equal(t T, expected, actual any, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotEqual
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -66,6 +67,7 @@ func Equal(t T, expected, actual any, msgAndArgs ...any) bool {
 // [ComparisonOperators]: https://go.dev/ref/spec#Comparison_operators.
 func EqualT[V comparable](t T, expected, actual V, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotEqualT
 	if expected != actual {
 		return failWithDiff(t, expected, actual, msgAndArgs...)
 	}
@@ -141,6 +143,7 @@ func NotEqualT[V comparable](t T, expected, actual V, msgAndArgs ...any) bool {
 //	failure: uint32(123), int32(456)
 func EqualValues(t T, expected, actual any, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotEqualValues
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/equal_pointer.go
+++ b/internal/assertions/equal_pointer.go
@@ -23,6 +23,7 @@ import "fmt"
 //	failure: &staticVar, ptr("static string")
 func Same(t T, expected, actual any, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotSame
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -56,6 +57,7 @@ func Same(t T, expected, actual any, msgAndArgs ...any) bool {
 //	failure: &staticVar, ptr("static string")
 func SameT[P any](t T, expected, actual *P, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotSameT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/equal_unary.go
+++ b/internal/assertions/equal_unary.go
@@ -20,6 +20,7 @@ import (
 //	failure: "not nil"
 func Nil(t T, object any, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotNil
 	if isNil(object) {
 		return true
 	}
@@ -72,6 +73,7 @@ func NotNil(t T, object any, msgAndArgs ...any) bool {
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Empty(t T, object any, msgAndArgs ...any) bool {
 	// Domain: equality
+	// Opposite: NotEmpty
 	pass := isEmpty(object)
 	if !pass {
 		if h, ok := t.(H); ok {

--- a/internal/assertions/error.go
+++ b/internal/assertions/error.go
@@ -64,6 +64,7 @@ func NoError(t T, err error, msgAndArgs ...any) bool {
 //	failure: nil
 func Error(t T, err error, msgAndArgs ...any) bool {
 	// Domain: error
+	// Opposite: NoError
 	if err == nil {
 		if h, ok := t.(H); ok {
 			h.Helper()
@@ -148,6 +149,7 @@ func ErrorContains(t T, err error, contains string, msgAndArgs ...any) bool {
 //	failure: ErrTest, io.EOF
 func ErrorIs(t T, err, target error, msgAndArgs ...any) bool {
 	// Domain: error
+	// Opposite: NotErrorIs
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -219,6 +221,7 @@ func NotErrorIs(t T, err, target error, msgAndArgs ...any) bool {
 //	failure: ErrTest, new(*dummyError)
 func ErrorAs(t T, err error, target any, msgAndArgs ...any) bool {
 	// Domain: error
+	// Opposite: NotErrorAs
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/file.go
+++ b/internal/assertions/file.go
@@ -22,6 +22,7 @@ import (
 //	failure: filepath.Join(testDataPath(),"non_existing_file")
 func FileExists(t T, path string, msgAndArgs ...any) bool {
 	// Domain: file
+	// Opposite: FileNotExists
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -80,6 +81,7 @@ func FileNotExists(t T, path string, msgAndArgs ...any) bool {
 //	failure: filepath.Join(testDataPath(),"non_existing_dir")
 func DirExists(t T, path string, msgAndArgs ...any) bool {
 	// Domain: file
+	// Opposite: DirNotExists
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -138,6 +140,7 @@ func DirNotExists(t T, path string, msgAndArgs ...any) bool {
 //	failure: filepath.Join(testDataPath(),"existing_file")
 func FileEmpty(t T, path string, msgAndArgs ...any) bool {
 	// Domain: file
+	// Opposite: FileNotEmpty
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/http.go
+++ b/internal/assertions/http.go
@@ -146,6 +146,7 @@ func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) s
 //	failure: httpBody, "GET", "/", url.Values{"name": []string{"Bob"}}, "Hello, World!"
 func HTTPBodyContains(t T, handler http.HandlerFunc, method, url string, values url.Values, str any, msgAndArgs ...any) bool {
 	// Domain: http
+	// Opposite: HTTPBodyNotContains
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/order.go
+++ b/internal/assertions/order.go
@@ -23,6 +23,7 @@ import (
 //	failure: []int{1, 1, 2}
 func IsIncreasing(t T, collection any, msgAndArgs ...any) bool {
 	// Domain: ordering
+	// Opposite: IsNonIncreasing
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -52,6 +53,7 @@ func IsIncreasing(t T, collection any, msgAndArgs ...any) bool {
 //	failure: []int{1, 1, 2}
 func IsIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool {
 	// Domain: ordering
+	// Opposite: IsNonIncreasingT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -80,6 +82,7 @@ func IsIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, m
 //	failure: []int{1, 4, 2}
 func SortedT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool {
 	// Domain: ordering
+	// Opposite: NotSortedT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -120,7 +123,13 @@ func NotSortedT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgA
 	return true
 }
 
-// IsNonIncreasing asserts that the collection is not increasing.
+// IsNonIncreasing asserts that the collection is not strictly increasing.
+//
+// This is the logical negation of [IsIncreasing]: it succeeds whenever
+// [IsIncreasing] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [1, 3, 2]).
+//
+// It is NOT the same as "weakly decreasing" (a[i] >= a[i+1] for all i).
 //
 // # Usage
 //
@@ -151,11 +160,17 @@ func IsNonIncreasing(t T, collection any, msgAndArgs ...any) bool {
 
 // IsNonIncreasingT asserts that a slice of [Ordered] is NOT strictly increasing.
 //
+// This is the logical negation of [IsIncreasingT]: it succeeds whenever
+// [IsIncreasingT] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [1, 3, 2]).
+//
+// It is NOT the same as "weakly decreasing" (a[i] >= a[i+1] for all i).
+//
 // # Usage
 //
-//	assertions.IsNonIncreasing(t, []int{2, 1, 1})
-//	assertions.IsNonIncreasing(t, []float{2, 1})
-//	assertions.IsNonIncreasing(t, []string{"b", "a"})
+//	assertions.IsNonIncreasingT(t, []int{2, 1, 1})
+//	assertions.IsNonIncreasingT(t, []float{2, 1})
+//	assertions.IsNonIncreasingT(t, []string{"b", "a"})
 //
 // # Examples
 //
@@ -189,6 +204,7 @@ func IsNonIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice
 //	failure: []int{1, 2, 3}
 func IsDecreasing(t T, collection any, msgAndArgs ...any) bool {
 	// Domain: ordering
+	// Opposite: IsNonDecreasing
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -219,6 +235,7 @@ func IsDecreasing(t T, collection any, msgAndArgs ...any) bool {
 //	failure: []int{1, 2, 3}
 func IsDecreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msgAndArgs ...any) bool {
 	// Domain: ordering
+	// Opposite: IsNonDecreasingT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -232,6 +249,12 @@ func IsDecreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, m
 }
 
 // IsNonDecreasing asserts that the collection is not strictly decreasing.
+//
+// This is the logical negation of [IsDecreasing]: it succeeds whenever
+// [IsDecreasing] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [3, 1, 2]).
+//
+// It is NOT the same as "weakly increasing" (a[i] <= a[i+1] for all i).
 //
 // # Usage
 //
@@ -260,7 +283,13 @@ func IsNonDecreasing(t T, collection any, msgAndArgs ...any) bool {
 	return Fail(t, "should not be decreasing", msgAndArgs...)
 }
 
-// IsNonDecreasingT asserts that a slice of [Ordered] is not decreasing.
+// IsNonDecreasingT asserts that a slice of [Ordered] is NOT strictly decreasing.
+//
+// This is the logical negation of [IsDecreasingT]: it succeeds whenever
+// [IsDecreasingT] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [3, 1, 2]).
+//
+// It is NOT the same as "weakly increasing" (a[i] <= a[i+1] for all i).
 //
 // # Usage
 //

--- a/internal/assertions/order_test.go
+++ b/internal/assertions/order_test.go
@@ -31,6 +31,30 @@ func TestOrder(t *testing.T) {
 	}
 }
 
+func TestOrderOppositePairs(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]orderAssertionKind{
+		{increasingKind, notIncreasingKind},
+		{decreasingKind, notDecreasingKind},
+		{sortedKind, notSortedKind},
+	}
+
+	for tc := range unifiedOrderCases() {
+		if tc.kind == errorCase {
+			continue
+		}
+		for _, pair := range pairs {
+			a := expectedStatusForAssertion(pair[0], tc.kind)
+			b := expectedStatusForAssertion(pair[1], tc.kind)
+			if a == b {
+				t.Errorf("%s: opposite pair (%d, %d) both returned %v for kind %d",
+					tc.name, pair[0], pair[1], a, tc.kind)
+			}
+		}
+	}
+}
+
 func TestOrderErrorMessages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/assertions/panic.go
+++ b/internal/assertions/panic.go
@@ -24,6 +24,7 @@ type PanicAssertionFunc func(t T, f func(), msgAndArgs ...any) bool
 //	failure: func() { }
 func Panics(t T, f func(), msgAndArgs ...any) bool {
 	// Domain: panic
+	// Opposite: NotPanics
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/string.go
+++ b/internal/assertions/string.go
@@ -26,6 +26,7 @@ import (
 //	failure: "^start", "not starting"
 func Regexp(t T, rx any, actual any, msgAndArgs ...any) bool {
 	// Domain: string
+	// Opposite: NotRegexp
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -62,6 +63,7 @@ func Regexp(t T, rx any, actual any, msgAndArgs ...any) bool {
 //	failure: "^start", "not starting"
 func RegexpT[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msgAndArgs ...any) bool {
 	// Domain: string
+	// Opposite: NotRegexpT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/assertions/type.go
+++ b/internal/assertions/type.go
@@ -20,6 +20,7 @@ import (
 //	failure: (*error)(nil), new(testing.T)
 func Implements(t T, interfaceObject any, object any, msgAndArgs ...any) bool {
 	// Domain: type
+	// Opposite: NotImplements
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -74,6 +75,7 @@ func NotImplements(t T, interfaceObject any, object any, msgAndArgs ...any) bool
 //	failure: int32(123), int64(456)
 func IsType(t T, expectedType, object any, msgAndArgs ...any) bool {
 	// Domain: type
+	// Opposite: IsNotType
 	if isType(expectedType, object) {
 		return true
 	}
@@ -95,6 +97,7 @@ func IsType(t T, expectedType, object any, msgAndArgs ...any) bool {
 //	failure: 123.123
 func IsOfTypeT[EType any](t T, object any, msgAndArgs ...any) bool {
 	// Domain: type
+	// Opposite: IsNotOfTypeT
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -164,6 +167,7 @@ func IsNotOfTypeT[EType any](t T, object any, msgAndArgs ...any) bool {
 //	failure: 1
 func Zero(t T, i any, msgAndArgs ...any) bool {
 	// Domain: type
+	// Opposite: NotZero
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
@@ -209,6 +213,7 @@ func NotZero(t T, i any, msgAndArgs ...any) bool {
 //	failure: reflect.String, 0
 func Kind(t T, expectedKind reflect.Kind, object any, msgAndArgs ...any) bool {
 	// Domain: type
+	// Opposite: NotKind
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}

--- a/internal/difflib/README.md
+++ b/internal/difflib/README.md
@@ -23,7 +23,7 @@ This fork of testify maintains **zero external dependencies** for the core asser
 By internalizing `difflib`, we:
 
 1. Eliminate the external dependency on an **unmaintained package** (last updated 2014)
-2. Gain full control to apply modernizations aligned with our go1.24 target
+2. Gain full control to apply modernizations aligned with our go1.25 target
 3. Can apply targeted fixes and optimizations specific to testify's use cases
 
 ## Modernizations Applied
@@ -94,7 +94,7 @@ As an internalized dependency, this copy can receive targeted improvements:
 
 ## Maintenance
 
-This internalized copy is maintained as part of github.com/go-openapi/testify/v2 and follows the same Go version requirements (currently go1.24). It does not track upstream go-difflib releases, as the original repository is no longer maintained and this copy has diverged through modernization and refactoring.
+This internalized copy is maintained as part of github.com/go-openapi/testify/v2 and follows the same Go version requirements (currently go1.25). It does not track upstream go-difflib releases, as the original repository is no longer maintained and this copy has diverged through modernization and refactoring.
 
 For issues or improvements specific to this internalized version, please file issues at:
 https://github.com/go-openapi/testify/issues

--- a/internal/spew/README.md
+++ b/internal/spew/README.md
@@ -21,7 +21,7 @@ custom Stringer/error interface handling, and hexdump-style byte array output.
 
 This fork of testify maintains **zero external dependencies** for its core assertion packages.
 By internalizing go-spew, we eliminate the external dependency while gaining full control over the code
-to apply modernizations aligned with our go1.24 target.
+to apply modernizations aligned with our go1.25 target.
 
 ## Modernizations Applied
 
@@ -71,7 +71,7 @@ The linting effort is still going on...
 ## Maintenance
 
 This internalized copy is maintained as part of github.com/go-openapi/testify/v2 and follows
-the same Go version requirements (currently go1.24).
+the same Go version requirements (currently go1.25).
 It does not track upstream go-spew releases, as it has diverged through modernization.
 
 For issues or improvements specific to this internalized version, please file issues at:

--- a/require/require_assertions.go
+++ b/require/require_assertions.go
@@ -1507,6 +1507,12 @@ func IsIncreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, m
 
 // IsNonDecreasing asserts that the collection is not strictly decreasing.
 //
+// This is the logical negation of [IsDecreasing]: it succeeds whenever
+// [IsDecreasing] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [3, 1, 2]).
+//
+// It is NOT the same as "weakly increasing" (a[i] <= a[i+1] for all i).
+//
 // # Usage
 //
 //	assertions.IsNonDecreasing(t, []int{1, 1, 2})
@@ -1530,7 +1536,13 @@ func IsNonDecreasing(t T, collection any, msgAndArgs ...any) {
 	t.FailNow()
 }
 
-// IsNonDecreasingT asserts that a slice of [Ordered] is not decreasing.
+// IsNonDecreasingT asserts that a slice of [Ordered] is NOT strictly decreasing.
+//
+// This is the logical negation of [IsDecreasingT]: it succeeds whenever
+// [IsDecreasingT] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [3, 1, 2]).
+//
+// It is NOT the same as "weakly increasing" (a[i] <= a[i+1] for all i).
 //
 // # Usage
 //
@@ -1555,7 +1567,13 @@ func IsNonDecreasingT[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice
 	t.FailNow()
 }
 
-// IsNonIncreasing asserts that the collection is not increasing.
+// IsNonIncreasing asserts that the collection is not strictly increasing.
+//
+// This is the logical negation of [IsIncreasing]: it succeeds whenever
+// [IsIncreasing] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [1, 3, 2]).
+//
+// It is NOT the same as "weakly decreasing" (a[i] >= a[i+1] for all i).
 //
 // # Usage
 //
@@ -1582,11 +1600,17 @@ func IsNonIncreasing(t T, collection any, msgAndArgs ...any) {
 
 // IsNonIncreasingT asserts that a slice of [Ordered] is NOT strictly increasing.
 //
+// This is the logical negation of [IsIncreasingT]: it succeeds whenever
+// [IsIncreasingT] would fail, including for sequences that are neither
+// increasing nor decreasing (e.g. [1, 3, 2]).
+//
+// It is NOT the same as "weakly decreasing" (a[i] >= a[i+1] for all i).
+//
 // # Usage
 //
-//	assertions.IsNonIncreasing(t, []int{2, 1, 1})
-//	assertions.IsNonIncreasing(t, []float{2, 1})
-//	assertions.IsNonIncreasing(t, []string{"b", "a"})
+//	assertions.IsNonIncreasingT(t, []int{2, 1, 1})
+//	assertions.IsNonIncreasingT(t, []float{2, 1})
+//	assertions.IsNonIncreasingT(t, []string{"b", "a"})
 //
 // # Examples
 //


### PR DESCRIPTION
> Motivation: the documentation site is peppered with counts of methods,
> assertion etc. Now these are maintained automatically using a generated
> hugo parameters file.

doc: added a generated quick index table.

This table displays all assertions with their logical opposite (complementary assertion) in compact form.

* evolved codegen to produce this table, using the new "opposite" comment annotation
* added notes relative to the confusing Decreasing/NonDecreasing pairs, with additional tests to relieve any doubt on these being complementary
* regenerated all code for go doc update

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
