### PR TITLE
fix: generated formatted variant should use variadic args

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ linters:
     - funlen
     - godox
     - gomoddirectives
+    - gomodguard
+    - gomodguard_v2
     - exhaustruct
     - nlreturn
     - nonamedreturns
@@ -46,6 +48,7 @@ linters:
       - legacy
       - std-error-handling
     paths:
+      - .worktrees
       - third_party$
       - builtin$
       - examples$
@@ -61,6 +64,7 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      - .worktrees
       - third_party$
       - builtin$
       - examples$

--- a/assert/assert_format.go
+++ b/assert/assert_format.go
@@ -22,7 +22,7 @@ func Blockedf(t T, ch any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Blocked(t, ch, forwardArgs(msg, args))
+	return assertions.Blocked(t, ch, forwardArgs(msg, args)...)
 }
 
 // BlockedTf is the same as [BlockedT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -32,7 +32,7 @@ func BlockedTf[E any, CHAN ~chan E](t T, ch CHAN, msg string, args ...any) bool 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.BlockedT[E, CHAN](t, ch, forwardArgs(msg, args))
+	return assertions.BlockedT[E, CHAN](t, ch, forwardArgs(msg, args)...)
 }
 
 // Conditionf is the same as [Condition], but it accepts a format string to format arguments like [fmt.Printf].
@@ -42,7 +42,7 @@ func Conditionf(t T, comp func() bool, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Condition(t, comp, forwardArgs(msg, args))
+	return assertions.Condition(t, comp, forwardArgs(msg, args)...)
 }
 
 // Consistentlyf is the same as [Consistently], but it accepts a format string to format arguments like [fmt.Printf].
@@ -52,7 +52,7 @@ func Consistentlyf[C Conditioner](t T, condition C, timeout time.Duration, tick 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Consistently[C](t, condition, timeout, tick, forwardArgs(msg, args))
+	return assertions.Consistently[C](t, condition, timeout, tick, forwardArgs(msg, args)...)
 }
 
 // Containsf is the same as [Contains], but it accepts a format string to format arguments like [fmt.Printf].
@@ -62,7 +62,7 @@ func Containsf(t T, s any, contains any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Contains(t, s, contains, forwardArgs(msg, args))
+	return assertions.Contains(t, s, contains, forwardArgs(msg, args)...)
 }
 
 // DirExistsf is the same as [DirExists], but it accepts a format string to format arguments like [fmt.Printf].
@@ -72,7 +72,7 @@ func DirExistsf(t T, path string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.DirExists(t, path, forwardArgs(msg, args))
+	return assertions.DirExists(t, path, forwardArgs(msg, args)...)
 }
 
 // DirNotExistsf is the same as [DirNotExists], but it accepts a format string to format arguments like [fmt.Printf].
@@ -82,7 +82,7 @@ func DirNotExistsf(t T, path string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.DirNotExists(t, path, forwardArgs(msg, args))
+	return assertions.DirNotExists(t, path, forwardArgs(msg, args)...)
 }
 
 // ElementsMatchf is the same as [ElementsMatch], but it accepts a format string to format arguments like [fmt.Printf].
@@ -92,7 +92,7 @@ func ElementsMatchf(t T, listA any, listB any, msg string, args ...any) (ok bool
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.ElementsMatch(t, listA, listB, forwardArgs(msg, args))
+	return assertions.ElementsMatch(t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // ElementsMatchTf is the same as [ElementsMatchT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -102,7 +102,7 @@ func ElementsMatchTf[E comparable](t T, listA []E, listB []E, msg string, args .
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.ElementsMatchT[E](t, listA, listB, forwardArgs(msg, args))
+	return assertions.ElementsMatchT[E](t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // Emptyf is the same as [Empty], but it accepts a format string to format arguments like [fmt.Printf].
@@ -112,7 +112,7 @@ func Emptyf(t T, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Empty(t, object, forwardArgs(msg, args))
+	return assertions.Empty(t, object, forwardArgs(msg, args)...)
 }
 
 // Equalf is the same as [Equal], but it accepts a format string to format arguments like [fmt.Printf].
@@ -122,7 +122,7 @@ func Equalf(t T, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Equal(t, expected, actual, forwardArgs(msg, args))
+	return assertions.Equal(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // EqualErrorf is the same as [EqualError], but it accepts a format string to format arguments like [fmt.Printf].
@@ -132,7 +132,7 @@ func EqualErrorf(t T, err error, errString string, msg string, args ...any) bool
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualError(t, err, errString, forwardArgs(msg, args))
+	return assertions.EqualError(t, err, errString, forwardArgs(msg, args)...)
 }
 
 // EqualExportedValuesf is the same as [EqualExportedValues], but it accepts a format string to format arguments like [fmt.Printf].
@@ -142,7 +142,7 @@ func EqualExportedValuesf(t T, expected any, actual any, msg string, args ...any
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualExportedValues(t, expected, actual, forwardArgs(msg, args))
+	return assertions.EqualExportedValues(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // EqualTf is the same as [EqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -152,7 +152,7 @@ func EqualTf[V comparable](t T, expected V, actual V, msg string, args ...any) b
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualT[V](t, expected, actual, forwardArgs(msg, args))
+	return assertions.EqualT[V](t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // EqualValuesf is the same as [EqualValues], but it accepts a format string to format arguments like [fmt.Printf].
@@ -162,7 +162,7 @@ func EqualValuesf(t T, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualValues(t, expected, actual, forwardArgs(msg, args))
+	return assertions.EqualValues(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Errorf is the same as [Error], but it accepts a format string to format arguments like [fmt.Printf].
@@ -172,7 +172,7 @@ func Errorf(t T, err error, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Error(t, err, forwardArgs(msg, args))
+	return assertions.Error(t, err, forwardArgs(msg, args)...)
 }
 
 // ErrorAsf is the same as [ErrorAs], but it accepts a format string to format arguments like [fmt.Printf].
@@ -182,7 +182,7 @@ func ErrorAsf(t T, err error, target any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.ErrorAs(t, err, target, forwardArgs(msg, args))
+	return assertions.ErrorAs(t, err, target, forwardArgs(msg, args)...)
 }
 
 // ErrorContainsf is the same as [ErrorContains], but it accepts a format string to format arguments like [fmt.Printf].
@@ -192,7 +192,7 @@ func ErrorContainsf(t T, err error, contains string, msg string, args ...any) bo
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.ErrorContains(t, err, contains, forwardArgs(msg, args))
+	return assertions.ErrorContains(t, err, contains, forwardArgs(msg, args)...)
 }
 
 // ErrorIsf is the same as [ErrorIs], but it accepts a format string to format arguments like [fmt.Printf].
@@ -202,7 +202,7 @@ func ErrorIsf(t T, err error, target error, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.ErrorIs(t, err, target, forwardArgs(msg, args))
+	return assertions.ErrorIs(t, err, target, forwardArgs(msg, args)...)
 }
 
 // Eventuallyf is the same as [Eventually], but it accepts a format string to format arguments like [fmt.Printf].
@@ -212,7 +212,7 @@ func Eventuallyf[C Conditioner](t T, condition C, timeout time.Duration, tick ti
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Eventually[C](t, condition, timeout, tick, forwardArgs(msg, args))
+	return assertions.Eventually[C](t, condition, timeout, tick, forwardArgs(msg, args)...)
 }
 
 // EventuallyWithf is the same as [EventuallyWith], but it accepts a format string to format arguments like [fmt.Printf].
@@ -222,7 +222,7 @@ func EventuallyWithf[C CollectibleConditioner](t T, condition C, timeout time.Du
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.EventuallyWith[C](t, condition, timeout, tick, forwardArgs(msg, args))
+	return assertions.EventuallyWith[C](t, condition, timeout, tick, forwardArgs(msg, args)...)
 }
 
 // Exactlyf is the same as [Exactly], but it accepts a format string to format arguments like [fmt.Printf].
@@ -232,7 +232,7 @@ func Exactlyf(t T, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Exactly(t, expected, actual, forwardArgs(msg, args))
+	return assertions.Exactly(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Failf is the same as [Fail], but it accepts a format string to format arguments like [fmt.Printf].
@@ -242,7 +242,7 @@ func Failf(t T, failureMessage string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Fail(t, failureMessage, forwardArgs(msg, args))
+	return assertions.Fail(t, failureMessage, forwardArgs(msg, args)...)
 }
 
 // FailNowf is the same as [FailNow], but it accepts a format string to format arguments like [fmt.Printf].
@@ -252,7 +252,7 @@ func FailNowf(t T, failureMessage string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.FailNow(t, failureMessage, forwardArgs(msg, args))
+	return assertions.FailNow(t, failureMessage, forwardArgs(msg, args)...)
 }
 
 // Falsef is the same as [False], but it accepts a format string to format arguments like [fmt.Printf].
@@ -262,7 +262,7 @@ func Falsef(t T, value bool, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.False(t, value, forwardArgs(msg, args))
+	return assertions.False(t, value, forwardArgs(msg, args)...)
 }
 
 // FalseTf is the same as [FalseT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -272,7 +272,7 @@ func FalseTf[B Boolean](t T, value B, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.FalseT[B](t, value, forwardArgs(msg, args))
+	return assertions.FalseT[B](t, value, forwardArgs(msg, args)...)
 }
 
 // FileEmptyf is the same as [FileEmpty], but it accepts a format string to format arguments like [fmt.Printf].
@@ -282,7 +282,7 @@ func FileEmptyf(t T, path string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileEmpty(t, path, forwardArgs(msg, args))
+	return assertions.FileEmpty(t, path, forwardArgs(msg, args)...)
 }
 
 // FileExistsf is the same as [FileExists], but it accepts a format string to format arguments like [fmt.Printf].
@@ -292,7 +292,7 @@ func FileExistsf(t T, path string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileExists(t, path, forwardArgs(msg, args))
+	return assertions.FileExists(t, path, forwardArgs(msg, args)...)
 }
 
 // FileNotEmptyf is the same as [FileNotEmpty], but it accepts a format string to format arguments like [fmt.Printf].
@@ -302,7 +302,7 @@ func FileNotEmptyf(t T, path string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileNotEmpty(t, path, forwardArgs(msg, args))
+	return assertions.FileNotEmpty(t, path, forwardArgs(msg, args)...)
 }
 
 // FileNotExistsf is the same as [FileNotExists], but it accepts a format string to format arguments like [fmt.Printf].
@@ -312,7 +312,7 @@ func FileNotExistsf(t T, path string, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileNotExists(t, path, forwardArgs(msg, args))
+	return assertions.FileNotExists(t, path, forwardArgs(msg, args)...)
 }
 
 // Greaterf is the same as [Greater], but it accepts a format string to format arguments like [fmt.Printf].
@@ -322,7 +322,7 @@ func Greaterf(t T, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Greater(t, e1, e2, forwardArgs(msg, args))
+	return assertions.Greater(t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // GreaterOrEqualf is the same as [GreaterOrEqual], but it accepts a format string to format arguments like [fmt.Printf].
@@ -332,7 +332,7 @@ func GreaterOrEqualf(t T, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.GreaterOrEqual(t, e1, e2, forwardArgs(msg, args))
+	return assertions.GreaterOrEqual(t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // GreaterOrEqualTf is the same as [GreaterOrEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -342,7 +342,7 @@ func GreaterOrEqualTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg st
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.GreaterOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args))
+	return assertions.GreaterOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // GreaterTf is the same as [GreaterT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -352,7 +352,7 @@ func GreaterTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg string, a
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.GreaterT[Orderable](t, e1, e2, forwardArgs(msg, args))
+	return assertions.GreaterT[Orderable](t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // HTTPBodyContainsf is the same as [HTTPBodyContains], but it accepts a format string to format arguments like [fmt.Printf].
@@ -362,7 +362,7 @@ func HTTPBodyContainsf(t T, handler http.HandlerFunc, method string, url string,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPBodyContains(t, handler, method, url, values, str, forwardArgs(msg, args))
+	return assertions.HTTPBodyContains(t, handler, method, url, values, str, forwardArgs(msg, args)...)
 }
 
 // HTTPBodyNotContainsf is the same as [HTTPBodyNotContains], but it accepts a format string to format arguments like [fmt.Printf].
@@ -372,7 +372,7 @@ func HTTPBodyNotContainsf(t T, handler http.HandlerFunc, method string, url stri
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPBodyNotContains(t, handler, method, url, values, str, forwardArgs(msg, args))
+	return assertions.HTTPBodyNotContains(t, handler, method, url, values, str, forwardArgs(msg, args)...)
 }
 
 // HTTPErrorf is the same as [HTTPError], but it accepts a format string to format arguments like [fmt.Printf].
@@ -382,7 +382,7 @@ func HTTPErrorf(t T, handler http.HandlerFunc, method string, url string, values
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPError(t, handler, method, url, values, forwardArgs(msg, args))
+	return assertions.HTTPError(t, handler, method, url, values, forwardArgs(msg, args)...)
 }
 
 // HTTPRedirectf is the same as [HTTPRedirect], but it accepts a format string to format arguments like [fmt.Printf].
@@ -392,7 +392,7 @@ func HTTPRedirectf(t T, handler http.HandlerFunc, method string, url string, val
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPRedirect(t, handler, method, url, values, forwardArgs(msg, args))
+	return assertions.HTTPRedirect(t, handler, method, url, values, forwardArgs(msg, args)...)
 }
 
 // HTTPStatusCodef is the same as [HTTPStatusCode], but it accepts a format string to format arguments like [fmt.Printf].
@@ -402,7 +402,7 @@ func HTTPStatusCodef(t T, handler http.HandlerFunc, method string, url string, v
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPStatusCode(t, handler, method, url, values, statuscode, forwardArgs(msg, args))
+	return assertions.HTTPStatusCode(t, handler, method, url, values, statuscode, forwardArgs(msg, args)...)
 }
 
 // HTTPSuccessf is the same as [HTTPSuccess], but it accepts a format string to format arguments like [fmt.Printf].
@@ -412,7 +412,7 @@ func HTTPSuccessf(t T, handler http.HandlerFunc, method string, url string, valu
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPSuccess(t, handler, method, url, values, forwardArgs(msg, args))
+	return assertions.HTTPSuccess(t, handler, method, url, values, forwardArgs(msg, args)...)
 }
 
 // Implementsf is the same as [Implements], but it accepts a format string to format arguments like [fmt.Printf].
@@ -422,7 +422,7 @@ func Implementsf(t T, interfaceObject any, object any, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Implements(t, interfaceObject, object, forwardArgs(msg, args))
+	return assertions.Implements(t, interfaceObject, object, forwardArgs(msg, args)...)
 }
 
 // InDeltaf is the same as [InDelta], but it accepts a format string to format arguments like [fmt.Printf].
@@ -432,7 +432,7 @@ func InDeltaf(t T, expected any, actual any, delta float64, msg string, args ...
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDelta(t, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDelta(t, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InDeltaMapValuesf is the same as [InDeltaMapValues], but it accepts a format string to format arguments like [fmt.Printf].
@@ -442,7 +442,7 @@ func InDeltaMapValuesf(t T, expected any, actual any, delta float64, msg string,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDeltaMapValues(t, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDeltaMapValues(t, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InDeltaSlicef is the same as [InDeltaSlice], but it accepts a format string to format arguments like [fmt.Printf].
@@ -452,7 +452,7 @@ func InDeltaSlicef(t T, expected any, actual any, delta float64, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDeltaSlice(t, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDeltaSlice(t, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InDeltaTf is the same as [InDeltaT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -462,7 +462,7 @@ func InDeltaTf[Number Measurable](t T, expected Number, actual Number, delta Num
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDeltaT[Number](t, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDeltaT[Number](t, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InEpsilonf is the same as [InEpsilon], but it accepts a format string to format arguments like [fmt.Printf].
@@ -472,7 +472,7 @@ func InEpsilonf(t T, expected any, actual any, epsilon float64, msg string, args
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilon(t, expected, actual, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilon(t, expected, actual, epsilon, forwardArgs(msg, args)...)
 }
 
 // InEpsilonSlicef is the same as [InEpsilonSlice], but it accepts a format string to format arguments like [fmt.Printf].
@@ -482,7 +482,7 @@ func InEpsilonSlicef(t T, expected any, actual any, epsilon float64, msg string,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilonSlice(t, expected, actual, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilonSlice(t, expected, actual, epsilon, forwardArgs(msg, args)...)
 }
 
 // InEpsilonSymmetricf is the same as [InEpsilonSymmetric], but it accepts a format string to format arguments like [fmt.Printf].
@@ -492,7 +492,7 @@ func InEpsilonSymmetricf(t T, x any, y any, epsilon float64, msg string, args ..
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilonSymmetric(t, x, y, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilonSymmetric(t, x, y, epsilon, forwardArgs(msg, args)...)
 }
 
 // InEpsilonSymmetricTf is the same as [InEpsilonSymmetricT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -502,7 +502,7 @@ func InEpsilonSymmetricTf[Number Measurable](t T, x Number, y Number, epsilon fl
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilonSymmetricT[Number](t, x, y, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilonSymmetricT[Number](t, x, y, epsilon, forwardArgs(msg, args)...)
 }
 
 // InEpsilonTf is the same as [InEpsilonT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -512,7 +512,7 @@ func InEpsilonTf[Number Measurable](t T, expected Number, actual Number, epsilon
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilonT[Number](t, expected, actual, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilonT[Number](t, expected, actual, epsilon, forwardArgs(msg, args)...)
 }
 
 // IsDecreasingf is the same as [IsDecreasing], but it accepts a format string to format arguments like [fmt.Printf].
@@ -522,7 +522,7 @@ func IsDecreasingf(t T, collection any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsDecreasing(t, collection, forwardArgs(msg, args))
+	return assertions.IsDecreasing(t, collection, forwardArgs(msg, args)...)
 }
 
 // IsDecreasingTf is the same as [IsDecreasingT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -532,7 +532,7 @@ func IsDecreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args))
+	return assertions.IsDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...)
 }
 
 // IsIncreasingf is the same as [IsIncreasing], but it accepts a format string to format arguments like [fmt.Printf].
@@ -542,7 +542,7 @@ func IsIncreasingf(t T, collection any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsIncreasing(t, collection, forwardArgs(msg, args))
+	return assertions.IsIncreasing(t, collection, forwardArgs(msg, args)...)
 }
 
 // IsIncreasingTf is the same as [IsIncreasingT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -552,7 +552,7 @@ func IsIncreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args))
+	return assertions.IsIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...)
 }
 
 // IsNonDecreasingf is the same as [IsNonDecreasing], but it accepts a format string to format arguments like [fmt.Printf].
@@ -562,7 +562,7 @@ func IsNonDecreasingf(t T, collection any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNonDecreasing(t, collection, forwardArgs(msg, args))
+	return assertions.IsNonDecreasing(t, collection, forwardArgs(msg, args)...)
 }
 
 // IsNonDecreasingTf is the same as [IsNonDecreasingT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -572,7 +572,7 @@ func IsNonDecreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlic
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNonDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args))
+	return assertions.IsNonDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...)
 }
 
 // IsNonIncreasingf is the same as [IsNonIncreasing], but it accepts a format string to format arguments like [fmt.Printf].
@@ -582,7 +582,7 @@ func IsNonIncreasingf(t T, collection any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNonIncreasing(t, collection, forwardArgs(msg, args))
+	return assertions.IsNonIncreasing(t, collection, forwardArgs(msg, args)...)
 }
 
 // IsNonIncreasingTf is the same as [IsNonIncreasingT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -592,7 +592,7 @@ func IsNonIncreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlic
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNonIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args))
+	return assertions.IsNonIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...)
 }
 
 // IsNotOfTypeTf is the same as [IsNotOfTypeT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -602,7 +602,7 @@ func IsNotOfTypeTf[EType any](t T, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNotOfTypeT[EType](t, object, forwardArgs(msg, args))
+	return assertions.IsNotOfTypeT[EType](t, object, forwardArgs(msg, args)...)
 }
 
 // IsNotTypef is the same as [IsNotType], but it accepts a format string to format arguments like [fmt.Printf].
@@ -612,7 +612,7 @@ func IsNotTypef(t T, theType any, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNotType(t, theType, object, forwardArgs(msg, args))
+	return assertions.IsNotType(t, theType, object, forwardArgs(msg, args)...)
 }
 
 // IsOfTypeTf is the same as [IsOfTypeT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -622,7 +622,7 @@ func IsOfTypeTf[EType any](t T, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsOfTypeT[EType](t, object, forwardArgs(msg, args))
+	return assertions.IsOfTypeT[EType](t, object, forwardArgs(msg, args)...)
 }
 
 // IsTypef is the same as [IsType], but it accepts a format string to format arguments like [fmt.Printf].
@@ -632,7 +632,7 @@ func IsTypef(t T, expectedType any, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsType(t, expectedType, object, forwardArgs(msg, args))
+	return assertions.IsType(t, expectedType, object, forwardArgs(msg, args)...)
 }
 
 // JSONEqf is the same as [JSONEq], but it accepts a format string to format arguments like [fmt.Printf].
@@ -642,7 +642,7 @@ func JSONEqf(t T, expected string, actual string, msg string, args ...any) bool 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONEq(t, expected, actual, forwardArgs(msg, args))
+	return assertions.JSONEq(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // JSONEqBytesf is the same as [JSONEqBytes], but it accepts a format string to format arguments like [fmt.Printf].
@@ -652,7 +652,7 @@ func JSONEqBytesf(t T, expected []byte, actual []byte, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONEqBytes(t, expected, actual, forwardArgs(msg, args))
+	return assertions.JSONEqBytes(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // JSONEqTf is the same as [JSONEqT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -662,7 +662,7 @@ func JSONEqTf[EDoc, ADoc RText](t T, expected EDoc, actual ADoc, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args))
+	return assertions.JSONEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // JSONMarshalAsTf is the same as [JSONMarshalAsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -672,7 +672,7 @@ func JSONMarshalAsTf[EDoc RText](t T, expected EDoc, object any, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args))
+	return assertions.JSONMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args)...)
 }
 
 // JSONUnmarshalAsTf is the same as [JSONUnmarshalAsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -682,7 +682,7 @@ func JSONUnmarshalAsTf[Object any, ADoc RText](t T, expected Object, jazon ADoc,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONUnmarshalAsT[Object, ADoc](t, expected, jazon, forwardArgs(msg, args))
+	return assertions.JSONUnmarshalAsT[Object, ADoc](t, expected, jazon, forwardArgs(msg, args)...)
 }
 
 // Kindf is the same as [Kind], but it accepts a format string to format arguments like [fmt.Printf].
@@ -692,7 +692,7 @@ func Kindf(t T, expectedKind reflect.Kind, object any, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Kind(t, expectedKind, object, forwardArgs(msg, args))
+	return assertions.Kind(t, expectedKind, object, forwardArgs(msg, args)...)
 }
 
 // Lenf is the same as [Len], but it accepts a format string to format arguments like [fmt.Printf].
@@ -702,7 +702,7 @@ func Lenf(t T, object any, length int, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Len(t, object, length, forwardArgs(msg, args))
+	return assertions.Len(t, object, length, forwardArgs(msg, args)...)
 }
 
 // Lessf is the same as [Less], but it accepts a format string to format arguments like [fmt.Printf].
@@ -712,7 +712,7 @@ func Lessf(t T, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Less(t, e1, e2, forwardArgs(msg, args))
+	return assertions.Less(t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // LessOrEqualf is the same as [LessOrEqual], but it accepts a format string to format arguments like [fmt.Printf].
@@ -722,7 +722,7 @@ func LessOrEqualf(t T, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.LessOrEqual(t, e1, e2, forwardArgs(msg, args))
+	return assertions.LessOrEqual(t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // LessOrEqualTf is the same as [LessOrEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -732,7 +732,7 @@ func LessOrEqualTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg strin
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.LessOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args))
+	return assertions.LessOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // LessTf is the same as [LessT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -742,7 +742,7 @@ func LessTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg string, args
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.LessT[Orderable](t, e1, e2, forwardArgs(msg, args))
+	return assertions.LessT[Orderable](t, e1, e2, forwardArgs(msg, args)...)
 }
 
 // MapContainsTf is the same as [MapContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -752,7 +752,7 @@ func MapContainsTf[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msg str
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.MapContainsT[Map, K, V](t, m, key, forwardArgs(msg, args))
+	return assertions.MapContainsT[Map, K, V](t, m, key, forwardArgs(msg, args)...)
 }
 
 // MapEqualTf is the same as [MapEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -762,7 +762,7 @@ func MapEqualTf[K, V comparable](t T, listA map[K]V, listB map[K]V, msg string, 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.MapEqualT[K, V](t, listA, listB, forwardArgs(msg, args))
+	return assertions.MapEqualT[K, V](t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // MapNotContainsTf is the same as [MapNotContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -772,7 +772,7 @@ func MapNotContainsTf[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msg 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.MapNotContainsT[Map, K, V](t, m, key, forwardArgs(msg, args))
+	return assertions.MapNotContainsT[Map, K, V](t, m, key, forwardArgs(msg, args)...)
 }
 
 // MapNotEqualTf is the same as [MapNotEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -782,7 +782,7 @@ func MapNotEqualTf[K, V comparable](t T, listA map[K]V, listB map[K]V, msg strin
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.MapNotEqualT[K, V](t, listA, listB, forwardArgs(msg, args))
+	return assertions.MapNotEqualT[K, V](t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // Negativef is the same as [Negative], but it accepts a format string to format arguments like [fmt.Printf].
@@ -792,7 +792,7 @@ func Negativef(t T, e any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Negative(t, e, forwardArgs(msg, args))
+	return assertions.Negative(t, e, forwardArgs(msg, args)...)
 }
 
 // NegativeTf is the same as [NegativeT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -802,7 +802,7 @@ func NegativeTf[SignedNumber SignedNumeric](t T, e SignedNumber, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NegativeT[SignedNumber](t, e, forwardArgs(msg, args))
+	return assertions.NegativeT[SignedNumber](t, e, forwardArgs(msg, args)...)
 }
 
 // Neverf is the same as [Never], but it accepts a format string to format arguments like [fmt.Printf].
@@ -812,7 +812,7 @@ func Neverf[C NeverConditioner](t T, condition C, timeout time.Duration, tick ti
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Never[C](t, condition, timeout, tick, forwardArgs(msg, args))
+	return assertions.Never[C](t, condition, timeout, tick, forwardArgs(msg, args)...)
 }
 
 // Nilf is the same as [Nil], but it accepts a format string to format arguments like [fmt.Printf].
@@ -822,7 +822,7 @@ func Nilf(t T, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Nil(t, object, forwardArgs(msg, args))
+	return assertions.Nil(t, object, forwardArgs(msg, args)...)
 }
 
 // NoErrorf is the same as [NoError], but it accepts a format string to format arguments like [fmt.Printf].
@@ -832,7 +832,7 @@ func NoErrorf(t T, err error, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NoError(t, err, forwardArgs(msg, args))
+	return assertions.NoError(t, err, forwardArgs(msg, args)...)
 }
 
 // NoFileDescriptorLeakf is the same as [NoFileDescriptorLeak], but it accepts a format string to format arguments like [fmt.Printf].
@@ -842,7 +842,7 @@ func NoFileDescriptorLeakf(t T, tested func(), msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NoFileDescriptorLeak(t, tested, forwardArgs(msg, args))
+	return assertions.NoFileDescriptorLeak(t, tested, forwardArgs(msg, args)...)
 }
 
 // NoGoRoutineLeakf is the same as [NoGoRoutineLeak], but it accepts a format string to format arguments like [fmt.Printf].
@@ -852,7 +852,7 @@ func NoGoRoutineLeakf(t T, tested func(), msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NoGoRoutineLeak(t, tested, forwardArgs(msg, args))
+	return assertions.NoGoRoutineLeak(t, tested, forwardArgs(msg, args)...)
 }
 
 // NotBlockedf is the same as [NotBlocked], but it accepts a format string to format arguments like [fmt.Printf].
@@ -862,7 +862,7 @@ func NotBlockedf(t T, ch any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotBlocked(t, ch, forwardArgs(msg, args))
+	return assertions.NotBlocked(t, ch, forwardArgs(msg, args)...)
 }
 
 // NotBlockedTf is the same as [NotBlockedT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -872,7 +872,7 @@ func NotBlockedTf[E any, CHAN ~chan E](t T, ch CHAN, msg string, args ...any) bo
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotBlockedT[E, CHAN](t, ch, forwardArgs(msg, args))
+	return assertions.NotBlockedT[E, CHAN](t, ch, forwardArgs(msg, args)...)
 }
 
 // NotContainsf is the same as [NotContains], but it accepts a format string to format arguments like [fmt.Printf].
@@ -882,7 +882,7 @@ func NotContainsf(t T, s any, contains any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotContains(t, s, contains, forwardArgs(msg, args))
+	return assertions.NotContains(t, s, contains, forwardArgs(msg, args)...)
 }
 
 // NotElementsMatchf is the same as [NotElementsMatch], but it accepts a format string to format arguments like [fmt.Printf].
@@ -892,7 +892,7 @@ func NotElementsMatchf(t T, listA any, listB any, msg string, args ...any) (ok b
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotElementsMatch(t, listA, listB, forwardArgs(msg, args))
+	return assertions.NotElementsMatch(t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // NotElementsMatchTf is the same as [NotElementsMatchT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -902,7 +902,7 @@ func NotElementsMatchTf[E comparable](t T, listA []E, listB []E, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotElementsMatchT[E](t, listA, listB, forwardArgs(msg, args))
+	return assertions.NotElementsMatchT[E](t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // NotEmptyf is the same as [NotEmpty], but it accepts a format string to format arguments like [fmt.Printf].
@@ -912,7 +912,7 @@ func NotEmptyf(t T, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEmpty(t, object, forwardArgs(msg, args))
+	return assertions.NotEmpty(t, object, forwardArgs(msg, args)...)
 }
 
 // NotEqualf is the same as [NotEqual], but it accepts a format string to format arguments like [fmt.Printf].
@@ -922,7 +922,7 @@ func NotEqualf(t T, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEqual(t, expected, actual, forwardArgs(msg, args))
+	return assertions.NotEqual(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotEqualTf is the same as [NotEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -932,7 +932,7 @@ func NotEqualTf[V comparable](t T, expected V, actual V, msg string, args ...any
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEqualT[V](t, expected, actual, forwardArgs(msg, args))
+	return assertions.NotEqualT[V](t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotEqualValuesf is the same as [NotEqualValues], but it accepts a format string to format arguments like [fmt.Printf].
@@ -942,7 +942,7 @@ func NotEqualValuesf(t T, expected any, actual any, msg string, args ...any) boo
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEqualValues(t, expected, actual, forwardArgs(msg, args))
+	return assertions.NotEqualValues(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotErrorAsf is the same as [NotErrorAs], but it accepts a format string to format arguments like [fmt.Printf].
@@ -952,7 +952,7 @@ func NotErrorAsf(t T, err error, target any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotErrorAs(t, err, target, forwardArgs(msg, args))
+	return assertions.NotErrorAs(t, err, target, forwardArgs(msg, args)...)
 }
 
 // NotErrorIsf is the same as [NotErrorIs], but it accepts a format string to format arguments like [fmt.Printf].
@@ -962,7 +962,7 @@ func NotErrorIsf(t T, err error, target error, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotErrorIs(t, err, target, forwardArgs(msg, args))
+	return assertions.NotErrorIs(t, err, target, forwardArgs(msg, args)...)
 }
 
 // NotImplementsf is the same as [NotImplements], but it accepts a format string to format arguments like [fmt.Printf].
@@ -972,7 +972,7 @@ func NotImplementsf(t T, interfaceObject any, object any, msg string, args ...an
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotImplements(t, interfaceObject, object, forwardArgs(msg, args))
+	return assertions.NotImplements(t, interfaceObject, object, forwardArgs(msg, args)...)
 }
 
 // NotKindf is the same as [NotKind], but it accepts a format string to format arguments like [fmt.Printf].
@@ -982,7 +982,7 @@ func NotKindf(t T, expectedKind reflect.Kind, object any, msg string, args ...an
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotKind(t, expectedKind, object, forwardArgs(msg, args))
+	return assertions.NotKind(t, expectedKind, object, forwardArgs(msg, args)...)
 }
 
 // NotNilf is the same as [NotNil], but it accepts a format string to format arguments like [fmt.Printf].
@@ -992,7 +992,7 @@ func NotNilf(t T, object any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotNil(t, object, forwardArgs(msg, args))
+	return assertions.NotNil(t, object, forwardArgs(msg, args)...)
 }
 
 // NotPanicsf is the same as [NotPanics], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1002,7 +1002,7 @@ func NotPanicsf(t T, f func(), msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotPanics(t, f, forwardArgs(msg, args))
+	return assertions.NotPanics(t, f, forwardArgs(msg, args)...)
 }
 
 // NotRegexpf is the same as [NotRegexp], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1012,7 +1012,7 @@ func NotRegexpf(t T, rx any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotRegexp(t, rx, actual, forwardArgs(msg, args))
+	return assertions.NotRegexp(t, rx, actual, forwardArgs(msg, args)...)
 }
 
 // NotRegexpTf is the same as [NotRegexpT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1022,7 +1022,7 @@ func NotRegexpTf[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msg string, ar
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotRegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args))
+	return assertions.NotRegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args)...)
 }
 
 // NotSamef is the same as [NotSame], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1032,7 +1032,7 @@ func NotSamef(t T, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotSame(t, expected, actual, forwardArgs(msg, args))
+	return assertions.NotSame(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotSameTf is the same as [NotSameT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1042,7 +1042,7 @@ func NotSameTf[P any](t T, expected *P, actual *P, msg string, args ...any) bool
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotSameT[P](t, expected, actual, forwardArgs(msg, args))
+	return assertions.NotSameT[P](t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotSortedTf is the same as [NotSortedT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1052,7 +1052,7 @@ func NotSortedTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotSortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args))
+	return assertions.NotSortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...)
 }
 
 // NotSubsetf is the same as [NotSubset], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1062,7 +1062,7 @@ func NotSubsetf(t T, list any, subset any, msg string, args ...any) (ok bool) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotSubset(t, list, subset, forwardArgs(msg, args))
+	return assertions.NotSubset(t, list, subset, forwardArgs(msg, args)...)
 }
 
 // NotZerof is the same as [NotZero], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1072,7 +1072,7 @@ func NotZerof(t T, i any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotZero(t, i, forwardArgs(msg, args))
+	return assertions.NotZero(t, i, forwardArgs(msg, args)...)
 }
 
 // Panicsf is the same as [Panics], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1082,7 +1082,7 @@ func Panicsf(t T, f func(), msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Panics(t, f, forwardArgs(msg, args))
+	return assertions.Panics(t, f, forwardArgs(msg, args)...)
 }
 
 // PanicsWithErrorf is the same as [PanicsWithError], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1092,7 +1092,7 @@ func PanicsWithErrorf(t T, errString string, f func(), msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.PanicsWithError(t, errString, f, forwardArgs(msg, args))
+	return assertions.PanicsWithError(t, errString, f, forwardArgs(msg, args)...)
 }
 
 // PanicsWithValuef is the same as [PanicsWithValue], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1102,7 +1102,7 @@ func PanicsWithValuef(t T, expected any, f func(), msg string, args ...any) bool
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.PanicsWithValue(t, expected, f, forwardArgs(msg, args))
+	return assertions.PanicsWithValue(t, expected, f, forwardArgs(msg, args)...)
 }
 
 // Positivef is the same as [Positive], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1112,7 +1112,7 @@ func Positivef(t T, e any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Positive(t, e, forwardArgs(msg, args))
+	return assertions.Positive(t, e, forwardArgs(msg, args)...)
 }
 
 // PositiveTf is the same as [PositiveT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1122,7 +1122,7 @@ func PositiveTf[SignedNumber SignedNumeric](t T, e SignedNumber, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.PositiveT[SignedNumber](t, e, forwardArgs(msg, args))
+	return assertions.PositiveT[SignedNumber](t, e, forwardArgs(msg, args)...)
 }
 
 // Regexpf is the same as [Regexp], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1132,7 +1132,7 @@ func Regexpf(t T, rx any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Regexp(t, rx, actual, forwardArgs(msg, args))
+	return assertions.Regexp(t, rx, actual, forwardArgs(msg, args)...)
 }
 
 // RegexpTf is the same as [RegexpT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1142,7 +1142,7 @@ func RegexpTf[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msg string, args 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.RegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args))
+	return assertions.RegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args)...)
 }
 
 // Samef is the same as [Same], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1152,7 +1152,7 @@ func Samef(t T, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Same(t, expected, actual, forwardArgs(msg, args))
+	return assertions.Same(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // SameTf is the same as [SameT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1162,7 +1162,7 @@ func SameTf[P any](t T, expected *P, actual *P, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SameT[P](t, expected, actual, forwardArgs(msg, args))
+	return assertions.SameT[P](t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // SeqContainsTf is the same as [SeqContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1172,7 +1172,7 @@ func SeqContainsTf[E comparable](t T, iter iter.Seq[E], element E, msg string, a
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SeqContainsT[E](t, iter, element, forwardArgs(msg, args))
+	return assertions.SeqContainsT[E](t, iter, element, forwardArgs(msg, args)...)
 }
 
 // SeqNotContainsTf is the same as [SeqNotContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1182,7 +1182,7 @@ func SeqNotContainsTf[E comparable](t T, iter iter.Seq[E], element E, msg string
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SeqNotContainsT[E](t, iter, element, forwardArgs(msg, args))
+	return assertions.SeqNotContainsT[E](t, iter, element, forwardArgs(msg, args)...)
 }
 
 // SliceContainsTf is the same as [SliceContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1192,7 +1192,7 @@ func SliceContainsTf[Slice ~[]E, E comparable](t T, s Slice, element E, msg stri
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SliceContainsT[Slice, E](t, s, element, forwardArgs(msg, args))
+	return assertions.SliceContainsT[Slice, E](t, s, element, forwardArgs(msg, args)...)
 }
 
 // SliceEqualTf is the same as [SliceEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1202,7 +1202,7 @@ func SliceEqualTf[E comparable](t T, listA []E, listB []E, msg string, args ...a
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SliceEqualT[E](t, listA, listB, forwardArgs(msg, args))
+	return assertions.SliceEqualT[E](t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // SliceNotContainsTf is the same as [SliceNotContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1212,7 +1212,7 @@ func SliceNotContainsTf[Slice ~[]E, E comparable](t T, s Slice, element E, msg s
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SliceNotContainsT[Slice, E](t, s, element, forwardArgs(msg, args))
+	return assertions.SliceNotContainsT[Slice, E](t, s, element, forwardArgs(msg, args)...)
 }
 
 // SliceNotEqualTf is the same as [SliceNotEqualT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1222,7 +1222,7 @@ func SliceNotEqualTf[E comparable](t T, listA []E, listB []E, msg string, args .
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SliceNotEqualT[E](t, listA, listB, forwardArgs(msg, args))
+	return assertions.SliceNotEqualT[E](t, listA, listB, forwardArgs(msg, args)...)
 }
 
 // SliceNotSubsetTf is the same as [SliceNotSubsetT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1232,7 +1232,7 @@ func SliceNotSubsetTf[Slice ~[]E, E comparable](t T, list Slice, subset Slice, m
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SliceNotSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args))
+	return assertions.SliceNotSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args)...)
 }
 
 // SliceSubsetTf is the same as [SliceSubsetT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1242,7 +1242,7 @@ func SliceSubsetTf[Slice ~[]E, E comparable](t T, list Slice, subset Slice, msg 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SliceSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args))
+	return assertions.SliceSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args)...)
 }
 
 // SortedTf is the same as [SortedT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1252,7 +1252,7 @@ func SortedTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msg st
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.SortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args))
+	return assertions.SortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...)
 }
 
 // StringContainsTf is the same as [StringContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1262,7 +1262,7 @@ func StringContainsTf[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msg string
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.StringContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args))
+	return assertions.StringContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args)...)
 }
 
 // StringNotContainsTf is the same as [StringNotContainsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1272,7 +1272,7 @@ func StringNotContainsTf[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msg str
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.StringNotContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args))
+	return assertions.StringNotContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args)...)
 }
 
 // Subsetf is the same as [Subset], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1282,7 +1282,7 @@ func Subsetf(t T, list any, subset any, msg string, args ...any) (ok bool) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Subset(t, list, subset, forwardArgs(msg, args))
+	return assertions.Subset(t, list, subset, forwardArgs(msg, args)...)
 }
 
 // Truef is the same as [True], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1292,7 +1292,7 @@ func Truef(t T, value bool, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.True(t, value, forwardArgs(msg, args))
+	return assertions.True(t, value, forwardArgs(msg, args)...)
 }
 
 // TrueTf is the same as [TrueT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1302,7 +1302,7 @@ func TrueTf[B Boolean](t T, value B, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.TrueT[B](t, value, forwardArgs(msg, args))
+	return assertions.TrueT[B](t, value, forwardArgs(msg, args)...)
 }
 
 // WithinDurationf is the same as [WithinDuration], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1312,7 +1312,7 @@ func WithinDurationf(t T, expected time.Time, actual time.Time, delta time.Durat
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.WithinDuration(t, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.WithinDuration(t, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // WithinRangef is the same as [WithinRange], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1322,7 +1322,7 @@ func WithinRangef(t T, actual time.Time, start time.Time, end time.Time, msg str
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.WithinRange(t, actual, start, end, forwardArgs(msg, args))
+	return assertions.WithinRange(t, actual, start, end, forwardArgs(msg, args)...)
 }
 
 // YAMLEqf is the same as [YAMLEq], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1332,7 +1332,7 @@ func YAMLEqf(t T, expected string, actual string, msg string, args ...any) bool 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLEq(t, expected, actual, forwardArgs(msg, args))
+	return assertions.YAMLEq(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // YAMLEqBytesf is the same as [YAMLEqBytes], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1342,7 +1342,7 @@ func YAMLEqBytesf(t T, expected []byte, actual []byte, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLEqBytes(t, expected, actual, forwardArgs(msg, args))
+	return assertions.YAMLEqBytes(t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // YAMLEqTf is the same as [YAMLEqT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1352,7 +1352,7 @@ func YAMLEqTf[EDoc, ADoc RText](t T, expected EDoc, actual ADoc, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args))
+	return assertions.YAMLEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args)...)
 }
 
 // YAMLMarshalAsTf is the same as [YAMLMarshalAsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1362,7 +1362,7 @@ func YAMLMarshalAsTf[EDoc RText](t T, expected EDoc, object any, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args))
+	return assertions.YAMLMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args)...)
 }
 
 // YAMLUnmarshalAsTf is the same as [YAMLUnmarshalAsT], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1372,7 +1372,7 @@ func YAMLUnmarshalAsTf[Object any, ADoc RText](t T, expected Object, yamlDoc ADo
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLUnmarshalAsT[Object, ADoc](t, expected, yamlDoc, forwardArgs(msg, args))
+	return assertions.YAMLUnmarshalAsT[Object, ADoc](t, expected, yamlDoc, forwardArgs(msg, args)...)
 }
 
 // Zerof is the same as [Zero], but it accepts a format string to format arguments like [fmt.Printf].
@@ -1382,7 +1382,7 @@ func Zerof(t T, i any, msg string, args ...any) bool {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	return assertions.Zero(t, i, forwardArgs(msg, args))
+	return assertions.Zero(t, i, forwardArgs(msg, args)...)
 }
 
 func forwardArgs(msg string, args []any) []any {

--- a/assert/assert_forward.go
+++ b/assert/assert_forward.go
@@ -47,7 +47,7 @@ func (a *Assertions) Blockedf(ch any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Blocked(a.T, ch, forwardArgs(msg, args))
+	return assertions.Blocked(a.T, ch, forwardArgs(msg, args)...)
 }
 
 // Condition is the same as [Condition], as a method rather than a package-level function.
@@ -67,7 +67,7 @@ func (a *Assertions) Conditionf(comp func() bool, msg string, args ...any) bool 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Condition(a.T, comp, forwardArgs(msg, args))
+	return assertions.Condition(a.T, comp, forwardArgs(msg, args)...)
 }
 
 // Contains is the same as [Contains], as a method rather than a package-level function.
@@ -87,7 +87,7 @@ func (a *Assertions) Containsf(s any, contains any, msg string, args ...any) boo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Contains(a.T, s, contains, forwardArgs(msg, args))
+	return assertions.Contains(a.T, s, contains, forwardArgs(msg, args)...)
 }
 
 // DirExists is the same as [DirExists], as a method rather than a package-level function.
@@ -107,7 +107,7 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.DirExists(a.T, path, forwardArgs(msg, args))
+	return assertions.DirExists(a.T, path, forwardArgs(msg, args)...)
 }
 
 // DirNotExists is the same as [DirNotExists], as a method rather than a package-level function.
@@ -127,7 +127,7 @@ func (a *Assertions) DirNotExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.DirNotExists(a.T, path, forwardArgs(msg, args))
+	return assertions.DirNotExists(a.T, path, forwardArgs(msg, args)...)
 }
 
 // ElementsMatch is the same as [ElementsMatch], as a method rather than a package-level function.
@@ -147,7 +147,7 @@ func (a *Assertions) ElementsMatchf(listA any, listB any, msg string, args ...an
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.ElementsMatch(a.T, listA, listB, forwardArgs(msg, args))
+	return assertions.ElementsMatch(a.T, listA, listB, forwardArgs(msg, args)...)
 }
 
 // Empty is the same as [Empty], as a method rather than a package-level function.
@@ -167,7 +167,7 @@ func (a *Assertions) Emptyf(object any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Empty(a.T, object, forwardArgs(msg, args))
+	return assertions.Empty(a.T, object, forwardArgs(msg, args)...)
 }
 
 // Equal is the same as [Equal], as a method rather than a package-level function.
@@ -187,7 +187,7 @@ func (a *Assertions) Equalf(expected any, actual any, msg string, args ...any) b
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Equal(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.Equal(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // EqualError is the same as [EqualError], as a method rather than a package-level function.
@@ -207,7 +207,7 @@ func (a *Assertions) EqualErrorf(err error, errString string, msg string, args .
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualError(a.T, err, errString, forwardArgs(msg, args))
+	return assertions.EqualError(a.T, err, errString, forwardArgs(msg, args)...)
 }
 
 // EqualExportedValues is the same as [EqualExportedValues], as a method rather than a package-level function.
@@ -227,7 +227,7 @@ func (a *Assertions) EqualExportedValuesf(expected any, actual any, msg string, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualExportedValues(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.EqualExportedValues(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // EqualValues is the same as [EqualValues], as a method rather than a package-level function.
@@ -247,7 +247,7 @@ func (a *Assertions) EqualValuesf(expected any, actual any, msg string, args ...
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.EqualValues(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.EqualValues(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Error is the same as [Error], as a method rather than a package-level function.
@@ -267,7 +267,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Error(a.T, err, forwardArgs(msg, args))
+	return assertions.Error(a.T, err, forwardArgs(msg, args)...)
 }
 
 // ErrorAs is the same as [ErrorAs], as a method rather than a package-level function.
@@ -287,7 +287,7 @@ func (a *Assertions) ErrorAsf(err error, target any, msg string, args ...any) bo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.ErrorAs(a.T, err, target, forwardArgs(msg, args))
+	return assertions.ErrorAs(a.T, err, target, forwardArgs(msg, args)...)
 }
 
 // ErrorContains is the same as [ErrorContains], as a method rather than a package-level function.
@@ -307,7 +307,7 @@ func (a *Assertions) ErrorContainsf(err error, contains string, msg string, args
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.ErrorContains(a.T, err, contains, forwardArgs(msg, args))
+	return assertions.ErrorContains(a.T, err, contains, forwardArgs(msg, args)...)
 }
 
 // ErrorIs is the same as [ErrorIs], as a method rather than a package-level function.
@@ -327,7 +327,7 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...any) 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.ErrorIs(a.T, err, target, forwardArgs(msg, args))
+	return assertions.ErrorIs(a.T, err, target, forwardArgs(msg, args)...)
 }
 
 // Exactly is the same as [Exactly], as a method rather than a package-level function.
@@ -347,7 +347,7 @@ func (a *Assertions) Exactlyf(expected any, actual any, msg string, args ...any)
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Exactly(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.Exactly(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Fail is the same as [Fail], as a method rather than a package-level function.
@@ -367,7 +367,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...any) bool 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Fail(a.T, failureMessage, forwardArgs(msg, args))
+	return assertions.Fail(a.T, failureMessage, forwardArgs(msg, args)...)
 }
 
 // FailNow is the same as [FailNow], as a method rather than a package-level function.
@@ -387,7 +387,7 @@ func (a *Assertions) FailNowf(failureMessage string, msg string, args ...any) bo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.FailNow(a.T, failureMessage, forwardArgs(msg, args))
+	return assertions.FailNow(a.T, failureMessage, forwardArgs(msg, args)...)
 }
 
 // False is the same as [False], as a method rather than a package-level function.
@@ -407,7 +407,7 @@ func (a *Assertions) Falsef(value bool, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.False(a.T, value, forwardArgs(msg, args))
+	return assertions.False(a.T, value, forwardArgs(msg, args)...)
 }
 
 // FileEmpty is the same as [FileEmpty], as a method rather than a package-level function.
@@ -427,7 +427,7 @@ func (a *Assertions) FileEmptyf(path string, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileEmpty(a.T, path, forwardArgs(msg, args))
+	return assertions.FileEmpty(a.T, path, forwardArgs(msg, args)...)
 }
 
 // FileExists is the same as [FileExists], as a method rather than a package-level function.
@@ -447,7 +447,7 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileExists(a.T, path, forwardArgs(msg, args))
+	return assertions.FileExists(a.T, path, forwardArgs(msg, args)...)
 }
 
 // FileNotEmpty is the same as [FileNotEmpty], as a method rather than a package-level function.
@@ -467,7 +467,7 @@ func (a *Assertions) FileNotEmptyf(path string, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileNotEmpty(a.T, path, forwardArgs(msg, args))
+	return assertions.FileNotEmpty(a.T, path, forwardArgs(msg, args)...)
 }
 
 // FileNotExists is the same as [FileNotExists], as a method rather than a package-level function.
@@ -487,7 +487,7 @@ func (a *Assertions) FileNotExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.FileNotExists(a.T, path, forwardArgs(msg, args))
+	return assertions.FileNotExists(a.T, path, forwardArgs(msg, args)...)
 }
 
 // Greater is the same as [Greater], as a method rather than a package-level function.
@@ -507,7 +507,7 @@ func (a *Assertions) Greaterf(e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Greater(a.T, e1, e2, forwardArgs(msg, args))
+	return assertions.Greater(a.T, e1, e2, forwardArgs(msg, args)...)
 }
 
 // GreaterOrEqual is the same as [GreaterOrEqual], as a method rather than a package-level function.
@@ -527,7 +527,7 @@ func (a *Assertions) GreaterOrEqualf(e1 any, e2 any, msg string, args ...any) bo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.GreaterOrEqual(a.T, e1, e2, forwardArgs(msg, args))
+	return assertions.GreaterOrEqual(a.T, e1, e2, forwardArgs(msg, args)...)
 }
 
 // HTTPBodyContains is the same as [HTTPBodyContains], as a method rather than a package-level function.
@@ -547,7 +547,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPBodyContains(a.T, handler, method, url, values, str, forwardArgs(msg, args))
+	return assertions.HTTPBodyContains(a.T, handler, method, url, values, str, forwardArgs(msg, args)...)
 }
 
 // HTTPBodyNotContains is the same as [HTTPBodyNotContains], as a method rather than a package-level function.
@@ -567,7 +567,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPBodyNotContains(a.T, handler, method, url, values, str, forwardArgs(msg, args))
+	return assertions.HTTPBodyNotContains(a.T, handler, method, url, values, str, forwardArgs(msg, args)...)
 }
 
 // HTTPError is the same as [HTTPError], as a method rather than a package-level function.
@@ -587,7 +587,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPError(a.T, handler, method, url, values, forwardArgs(msg, args))
+	return assertions.HTTPError(a.T, handler, method, url, values, forwardArgs(msg, args)...)
 }
 
 // HTTPRedirect is the same as [HTTPRedirect], as a method rather than a package-level function.
@@ -607,7 +607,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPRedirect(a.T, handler, method, url, values, forwardArgs(msg, args))
+	return assertions.HTTPRedirect(a.T, handler, method, url, values, forwardArgs(msg, args)...)
 }
 
 // HTTPStatusCode is the same as [HTTPStatusCode], as a method rather than a package-level function.
@@ -627,7 +627,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPStatusCode(a.T, handler, method, url, values, statuscode, forwardArgs(msg, args))
+	return assertions.HTTPStatusCode(a.T, handler, method, url, values, statuscode, forwardArgs(msg, args)...)
 }
 
 // HTTPSuccess is the same as [HTTPSuccess], as a method rather than a package-level function.
@@ -647,7 +647,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.HTTPSuccess(a.T, handler, method, url, values, forwardArgs(msg, args))
+	return assertions.HTTPSuccess(a.T, handler, method, url, values, forwardArgs(msg, args)...)
 }
 
 // Implements is the same as [Implements], as a method rather than a package-level function.
@@ -667,7 +667,7 @@ func (a *Assertions) Implementsf(interfaceObject any, object any, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Implements(a.T, interfaceObject, object, forwardArgs(msg, args))
+	return assertions.Implements(a.T, interfaceObject, object, forwardArgs(msg, args)...)
 }
 
 // InDelta is the same as [InDelta], as a method rather than a package-level function.
@@ -687,7 +687,7 @@ func (a *Assertions) InDeltaf(expected any, actual any, delta float64, msg strin
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDelta(a.T, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDelta(a.T, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InDeltaMapValues is the same as [InDeltaMapValues], as a method rather than a package-level function.
@@ -707,7 +707,7 @@ func (a *Assertions) InDeltaMapValuesf(expected any, actual any, delta float64, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDeltaMapValues(a.T, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDeltaMapValues(a.T, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InDeltaSlice is the same as [InDeltaSlice], as a method rather than a package-level function.
@@ -727,7 +727,7 @@ func (a *Assertions) InDeltaSlicef(expected any, actual any, delta float64, msg 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.InDeltaSlice(a.T, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.InDeltaSlice(a.T, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // InEpsilon is the same as [InEpsilon], as a method rather than a package-level function.
@@ -747,7 +747,7 @@ func (a *Assertions) InEpsilonf(expected any, actual any, epsilon float64, msg s
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilon(a.T, expected, actual, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilon(a.T, expected, actual, epsilon, forwardArgs(msg, args)...)
 }
 
 // InEpsilonSlice is the same as [InEpsilonSlice], as a method rather than a package-level function.
@@ -767,7 +767,7 @@ func (a *Assertions) InEpsilonSlicef(expected any, actual any, epsilon float64, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilonSlice(a.T, expected, actual, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilonSlice(a.T, expected, actual, epsilon, forwardArgs(msg, args)...)
 }
 
 // InEpsilonSymmetric is the same as [InEpsilonSymmetric], as a method rather than a package-level function.
@@ -787,7 +787,7 @@ func (a *Assertions) InEpsilonSymmetricf(x any, y any, epsilon float64, msg stri
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.InEpsilonSymmetric(a.T, x, y, epsilon, forwardArgs(msg, args))
+	return assertions.InEpsilonSymmetric(a.T, x, y, epsilon, forwardArgs(msg, args)...)
 }
 
 // IsDecreasing is the same as [IsDecreasing], as a method rather than a package-level function.
@@ -807,7 +807,7 @@ func (a *Assertions) IsDecreasingf(collection any, msg string, args ...any) bool
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsDecreasing(a.T, collection, forwardArgs(msg, args))
+	return assertions.IsDecreasing(a.T, collection, forwardArgs(msg, args)...)
 }
 
 // IsIncreasing is the same as [IsIncreasing], as a method rather than a package-level function.
@@ -827,7 +827,7 @@ func (a *Assertions) IsIncreasingf(collection any, msg string, args ...any) bool
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsIncreasing(a.T, collection, forwardArgs(msg, args))
+	return assertions.IsIncreasing(a.T, collection, forwardArgs(msg, args)...)
 }
 
 // IsNonDecreasing is the same as [IsNonDecreasing], as a method rather than a package-level function.
@@ -847,7 +847,7 @@ func (a *Assertions) IsNonDecreasingf(collection any, msg string, args ...any) b
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNonDecreasing(a.T, collection, forwardArgs(msg, args))
+	return assertions.IsNonDecreasing(a.T, collection, forwardArgs(msg, args)...)
 }
 
 // IsNonIncreasing is the same as [IsNonIncreasing], as a method rather than a package-level function.
@@ -867,7 +867,7 @@ func (a *Assertions) IsNonIncreasingf(collection any, msg string, args ...any) b
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNonIncreasing(a.T, collection, forwardArgs(msg, args))
+	return assertions.IsNonIncreasing(a.T, collection, forwardArgs(msg, args)...)
 }
 
 // IsNotType is the same as [IsNotType], as a method rather than a package-level function.
@@ -887,7 +887,7 @@ func (a *Assertions) IsNotTypef(theType any, object any, msg string, args ...any
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsNotType(a.T, theType, object, forwardArgs(msg, args))
+	return assertions.IsNotType(a.T, theType, object, forwardArgs(msg, args)...)
 }
 
 // IsType is the same as [IsType], as a method rather than a package-level function.
@@ -907,7 +907,7 @@ func (a *Assertions) IsTypef(expectedType any, object any, msg string, args ...a
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.IsType(a.T, expectedType, object, forwardArgs(msg, args))
+	return assertions.IsType(a.T, expectedType, object, forwardArgs(msg, args)...)
 }
 
 // JSONEq is the same as [JSONEq], as a method rather than a package-level function.
@@ -927,7 +927,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONEq(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.JSONEq(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // JSONEqBytes is the same as [JSONEqBytes], as a method rather than a package-level function.
@@ -947,7 +947,7 @@ func (a *Assertions) JSONEqBytesf(expected []byte, actual []byte, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.JSONEqBytes(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.JSONEqBytes(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Kind is the same as [Kind], as a method rather than a package-level function.
@@ -967,7 +967,7 @@ func (a *Assertions) Kindf(expectedKind reflect.Kind, object any, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Kind(a.T, expectedKind, object, forwardArgs(msg, args))
+	return assertions.Kind(a.T, expectedKind, object, forwardArgs(msg, args)...)
 }
 
 // Len is the same as [Len], as a method rather than a package-level function.
@@ -987,7 +987,7 @@ func (a *Assertions) Lenf(object any, length int, msg string, args ...any) bool 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Len(a.T, object, length, forwardArgs(msg, args))
+	return assertions.Len(a.T, object, length, forwardArgs(msg, args)...)
 }
 
 // Less is the same as [Less], as a method rather than a package-level function.
@@ -1007,7 +1007,7 @@ func (a *Assertions) Lessf(e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Less(a.T, e1, e2, forwardArgs(msg, args))
+	return assertions.Less(a.T, e1, e2, forwardArgs(msg, args)...)
 }
 
 // LessOrEqual is the same as [LessOrEqual], as a method rather than a package-level function.
@@ -1027,7 +1027,7 @@ func (a *Assertions) LessOrEqualf(e1 any, e2 any, msg string, args ...any) bool 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.LessOrEqual(a.T, e1, e2, forwardArgs(msg, args))
+	return assertions.LessOrEqual(a.T, e1, e2, forwardArgs(msg, args)...)
 }
 
 // Negative is the same as [Negative], as a method rather than a package-level function.
@@ -1047,7 +1047,7 @@ func (a *Assertions) Negativef(e any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Negative(a.T, e, forwardArgs(msg, args))
+	return assertions.Negative(a.T, e, forwardArgs(msg, args)...)
 }
 
 // Nil is the same as [Nil], as a method rather than a package-level function.
@@ -1067,7 +1067,7 @@ func (a *Assertions) Nilf(object any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Nil(a.T, object, forwardArgs(msg, args))
+	return assertions.Nil(a.T, object, forwardArgs(msg, args)...)
 }
 
 // NoError is the same as [NoError], as a method rather than a package-level function.
@@ -1087,7 +1087,7 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NoError(a.T, err, forwardArgs(msg, args))
+	return assertions.NoError(a.T, err, forwardArgs(msg, args)...)
 }
 
 // NoFileDescriptorLeak is the same as [NoFileDescriptorLeak], as a method rather than a package-level function.
@@ -1107,7 +1107,7 @@ func (a *Assertions) NoFileDescriptorLeakf(tested func(), msg string, args ...an
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NoFileDescriptorLeak(a.T, tested, forwardArgs(msg, args))
+	return assertions.NoFileDescriptorLeak(a.T, tested, forwardArgs(msg, args)...)
 }
 
 // NoGoRoutineLeak is the same as [NoGoRoutineLeak], as a method rather than a package-level function.
@@ -1127,7 +1127,7 @@ func (a *Assertions) NoGoRoutineLeakf(tested func(), msg string, args ...any) bo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NoGoRoutineLeak(a.T, tested, forwardArgs(msg, args))
+	return assertions.NoGoRoutineLeak(a.T, tested, forwardArgs(msg, args)...)
 }
 
 // NotBlocked is the same as [NotBlocked], as a method rather than a package-level function.
@@ -1147,7 +1147,7 @@ func (a *Assertions) NotBlockedf(ch any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotBlocked(a.T, ch, forwardArgs(msg, args))
+	return assertions.NotBlocked(a.T, ch, forwardArgs(msg, args)...)
 }
 
 // NotContains is the same as [NotContains], as a method rather than a package-level function.
@@ -1167,7 +1167,7 @@ func (a *Assertions) NotContainsf(s any, contains any, msg string, args ...any) 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotContains(a.T, s, contains, forwardArgs(msg, args))
+	return assertions.NotContains(a.T, s, contains, forwardArgs(msg, args)...)
 }
 
 // NotElementsMatch is the same as [NotElementsMatch], as a method rather than a package-level function.
@@ -1187,7 +1187,7 @@ func (a *Assertions) NotElementsMatchf(listA any, listB any, msg string, args ..
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotElementsMatch(a.T, listA, listB, forwardArgs(msg, args))
+	return assertions.NotElementsMatch(a.T, listA, listB, forwardArgs(msg, args)...)
 }
 
 // NotEmpty is the same as [NotEmpty], as a method rather than a package-level function.
@@ -1207,7 +1207,7 @@ func (a *Assertions) NotEmptyf(object any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEmpty(a.T, object, forwardArgs(msg, args))
+	return assertions.NotEmpty(a.T, object, forwardArgs(msg, args)...)
 }
 
 // NotEqual is the same as [NotEqual], as a method rather than a package-level function.
@@ -1227,7 +1227,7 @@ func (a *Assertions) NotEqualf(expected any, actual any, msg string, args ...any
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEqual(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.NotEqual(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotEqualValues is the same as [NotEqualValues], as a method rather than a package-level function.
@@ -1247,7 +1247,7 @@ func (a *Assertions) NotEqualValuesf(expected any, actual any, msg string, args 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotEqualValues(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.NotEqualValues(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotErrorAs is the same as [NotErrorAs], as a method rather than a package-level function.
@@ -1267,7 +1267,7 @@ func (a *Assertions) NotErrorAsf(err error, target any, msg string, args ...any)
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotErrorAs(a.T, err, target, forwardArgs(msg, args))
+	return assertions.NotErrorAs(a.T, err, target, forwardArgs(msg, args)...)
 }
 
 // NotErrorIs is the same as [NotErrorIs], as a method rather than a package-level function.
@@ -1287,7 +1287,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...an
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotErrorIs(a.T, err, target, forwardArgs(msg, args))
+	return assertions.NotErrorIs(a.T, err, target, forwardArgs(msg, args)...)
 }
 
 // NotImplements is the same as [NotImplements], as a method rather than a package-level function.
@@ -1307,7 +1307,7 @@ func (a *Assertions) NotImplementsf(interfaceObject any, object any, msg string,
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotImplements(a.T, interfaceObject, object, forwardArgs(msg, args))
+	return assertions.NotImplements(a.T, interfaceObject, object, forwardArgs(msg, args)...)
 }
 
 // NotKind is the same as [NotKind], as a method rather than a package-level function.
@@ -1327,7 +1327,7 @@ func (a *Assertions) NotKindf(expectedKind reflect.Kind, object any, msg string,
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotKind(a.T, expectedKind, object, forwardArgs(msg, args))
+	return assertions.NotKind(a.T, expectedKind, object, forwardArgs(msg, args)...)
 }
 
 // NotNil is the same as [NotNil], as a method rather than a package-level function.
@@ -1347,7 +1347,7 @@ func (a *Assertions) NotNilf(object any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotNil(a.T, object, forwardArgs(msg, args))
+	return assertions.NotNil(a.T, object, forwardArgs(msg, args)...)
 }
 
 // NotPanics is the same as [NotPanics], as a method rather than a package-level function.
@@ -1367,7 +1367,7 @@ func (a *Assertions) NotPanicsf(f func(), msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotPanics(a.T, f, forwardArgs(msg, args))
+	return assertions.NotPanics(a.T, f, forwardArgs(msg, args)...)
 }
 
 // NotRegexp is the same as [NotRegexp], as a method rather than a package-level function.
@@ -1387,7 +1387,7 @@ func (a *Assertions) NotRegexpf(rx any, actual any, msg string, args ...any) boo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotRegexp(a.T, rx, actual, forwardArgs(msg, args))
+	return assertions.NotRegexp(a.T, rx, actual, forwardArgs(msg, args)...)
 }
 
 // NotSame is the same as [NotSame], as a method rather than a package-level function.
@@ -1407,7 +1407,7 @@ func (a *Assertions) NotSamef(expected any, actual any, msg string, args ...any)
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotSame(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.NotSame(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // NotSubset is the same as [NotSubset], as a method rather than a package-level function.
@@ -1427,7 +1427,7 @@ func (a *Assertions) NotSubsetf(list any, subset any, msg string, args ...any) (
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotSubset(a.T, list, subset, forwardArgs(msg, args))
+	return assertions.NotSubset(a.T, list, subset, forwardArgs(msg, args)...)
 }
 
 // NotZero is the same as [NotZero], as a method rather than a package-level function.
@@ -1447,7 +1447,7 @@ func (a *Assertions) NotZerof(i any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.NotZero(a.T, i, forwardArgs(msg, args))
+	return assertions.NotZero(a.T, i, forwardArgs(msg, args)...)
 }
 
 // Panics is the same as [Panics], as a method rather than a package-level function.
@@ -1467,7 +1467,7 @@ func (a *Assertions) Panicsf(f func(), msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Panics(a.T, f, forwardArgs(msg, args))
+	return assertions.Panics(a.T, f, forwardArgs(msg, args)...)
 }
 
 // PanicsWithError is the same as [PanicsWithError], as a method rather than a package-level function.
@@ -1487,7 +1487,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f func(), msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.PanicsWithError(a.T, errString, f, forwardArgs(msg, args))
+	return assertions.PanicsWithError(a.T, errString, f, forwardArgs(msg, args)...)
 }
 
 // PanicsWithValue is the same as [PanicsWithValue], as a method rather than a package-level function.
@@ -1507,7 +1507,7 @@ func (a *Assertions) PanicsWithValuef(expected any, f func(), msg string, args .
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.PanicsWithValue(a.T, expected, f, forwardArgs(msg, args))
+	return assertions.PanicsWithValue(a.T, expected, f, forwardArgs(msg, args)...)
 }
 
 // Positive is the same as [Positive], as a method rather than a package-level function.
@@ -1527,7 +1527,7 @@ func (a *Assertions) Positivef(e any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Positive(a.T, e, forwardArgs(msg, args))
+	return assertions.Positive(a.T, e, forwardArgs(msg, args)...)
 }
 
 // Regexp is the same as [Regexp], as a method rather than a package-level function.
@@ -1547,7 +1547,7 @@ func (a *Assertions) Regexpf(rx any, actual any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Regexp(a.T, rx, actual, forwardArgs(msg, args))
+	return assertions.Regexp(a.T, rx, actual, forwardArgs(msg, args)...)
 }
 
 // Same is the same as [Same], as a method rather than a package-level function.
@@ -1567,7 +1567,7 @@ func (a *Assertions) Samef(expected any, actual any, msg string, args ...any) bo
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Same(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.Same(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Subset is the same as [Subset], as a method rather than a package-level function.
@@ -1587,7 +1587,7 @@ func (a *Assertions) Subsetf(list any, subset any, msg string, args ...any) (ok 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Subset(a.T, list, subset, forwardArgs(msg, args))
+	return assertions.Subset(a.T, list, subset, forwardArgs(msg, args)...)
 }
 
 // True is the same as [True], as a method rather than a package-level function.
@@ -1607,7 +1607,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.True(a.T, value, forwardArgs(msg, args))
+	return assertions.True(a.T, value, forwardArgs(msg, args)...)
 }
 
 // WithinDuration is the same as [WithinDuration], as a method rather than a package-level function.
@@ -1627,7 +1627,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.WithinDuration(a.T, expected, actual, delta, forwardArgs(msg, args))
+	return assertions.WithinDuration(a.T, expected, actual, delta, forwardArgs(msg, args)...)
 }
 
 // WithinRange is the same as [WithinRange], as a method rather than a package-level function.
@@ -1647,7 +1647,7 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.WithinRange(a.T, actual, start, end, forwardArgs(msg, args))
+	return assertions.WithinRange(a.T, actual, start, end, forwardArgs(msg, args)...)
 }
 
 // YAMLEq is the same as [YAMLEq], as a method rather than a package-level function.
@@ -1667,7 +1667,7 @@ func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ..
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLEq(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.YAMLEq(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // YAMLEqBytes is the same as [YAMLEqBytes], as a method rather than a package-level function.
@@ -1687,7 +1687,7 @@ func (a *Assertions) YAMLEqBytesf(expected []byte, actual []byte, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.YAMLEqBytes(a.T, expected, actual, forwardArgs(msg, args))
+	return assertions.YAMLEqBytes(a.T, expected, actual, forwardArgs(msg, args)...)
 }
 
 // Zero is the same as [Zero], as a method rather than a package-level function.
@@ -1707,5 +1707,5 @@ func (a *Assertions) Zerof(i any, msg string, args ...any) bool {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	return assertions.Zero(a.T, i, forwardArgs(msg, args))
+	return assertions.Zero(a.T, i, forwardArgs(msg, args)...)
 }

--- a/codegen/internal/generator/templates/assertion_format.gotmpl
+++ b/codegen/internal/generator/templates/assertion_format.gotmpl
@@ -18,7 +18,7 @@ import (
 {{ docStringPackage $.Package }}
 func {{ .GenericName "f" }}(t T, {{ params .Params }}, msg string, args ...any) {{ returns .Returns }} {
 	if h, ok := t.(H); ok { h.Helper() }
-  return {{ .TargetPackage }}.{{ .GenericCallName }}(t, {{ forward .Params }}, forwardArgs(msg, args))
+  return {{ .TargetPackage }}.{{ .GenericCallName }}(t, {{ forward .Params }}, forwardArgs(msg, args)...)
 }
 {{- end }}
 

--- a/codegen/internal/generator/templates/assertion_forward.gotmpl
+++ b/codegen/internal/generator/templates/assertion_forward.gotmpl
@@ -43,7 +43,7 @@ func (a *{{ $.Receiver }}) {{.Name}}({{ params .Params }}, msgAndArgs ...any) {{
 {{ docStringPackage $.Package }}
 func (a *{{ $.Receiver }}){{ .Name }}f({{ params .Params }}, msg string, args ...any) {{ returns .Returns }} {
 	if h, ok := a.T.(H); ok { h.Helper() }
-  return {{ .TargetPackage }}.{{ .Name }}(a.T, {{ forward .Params }}, forwardArgs(msg, args))
+  return {{ .TargetPackage }}.{{ .Name }}(a.T, {{ forward .Params }}, forwardArgs(msg, args)...)
 }
   {{- end }}
 {{- end }}

--- a/codegen/internal/generator/templates/requirement_format.gotmpl
+++ b/codegen/internal/generator/templates/requirement_format.gotmpl
@@ -21,9 +21,9 @@ import (
 func {{ .GenericName "f" }}(t T, {{ params .Params }}, msg string, args ...any) {
 	if h, ok := t.(H); ok { h.Helper() }
       {{- if or (eq .Name "Fail") (eq .Name "FailNow") }}{{/* special semantics for these two, which can only fail */}}
-	_ = {{ .TargetPackage }}.{{ .Name }}(t, {{ forward .Params }}, forwardArgs(msg, args))
+	_ = {{ .TargetPackage }}.{{ .Name }}(t, {{ forward .Params }}, forwardArgs(msg, args)...)
       {{- else }}
-	if {{ .TargetPackage }}.{{ .GenericCallName }}(t, {{ forward .Params }}, forwardArgs(msg, args)) {
+	if {{ .TargetPackage }}.{{ .GenericCallName }}(t, {{ forward .Params }}, forwardArgs(msg, args)...) {
 		return
 	}
       {{- end }}

--- a/codegen/internal/generator/templates/requirement_forward.gotmpl
+++ b/codegen/internal/generator/templates/requirement_forward.gotmpl
@@ -55,9 +55,9 @@ func (a *{{ $.Receiver }}){{ .Name }}f({{ params .Params }}, msg string, args ..
     h.Helper()
   }
     {{- if or (eq .Name "Fail") (eq .Name "FailNow") }}{{/* special sema.Tics for these two, which can only fail */}}
-	_ = {{ .TargetPackage }}.{{ .Name }}(a.T, {{ forward .Params }}, forwardArgs(msg, args))
+	_ = {{ .TargetPackage }}.{{ .Name }}(a.T, {{ forward .Params }}, forwardArgs(msg, args)...)
     {{- else }}
-	if {{ .TargetPackage }}.{{ .Name }}(a.T, {{ forward .Params }}, forwardArgs(msg, args)) {
+	if {{ .TargetPackage }}.{{ .Name }}(a.T, {{ forward .Params }}, forwardArgs(msg, args)...) {
 		return
 	}
     {{- end }}

--- a/docs/doc-site/api/json.md
+++ b/docs/doc-site/api/json.md
@@ -148,7 +148,7 @@ func main() {
 |--|--|
 | [`assertions.JSONEq(t T, expected string, actual string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#JSONEq) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONEq](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L66)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONEq](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L65)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -261,7 +261,7 @@ func main() {
 |--|--|
 | [`assertions.JSONEqBytes(t T, expected []byte, actual []byte, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#JSONEqBytes) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONEqBytes](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L26)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONEqBytes](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L25)
 
 > **Maintainer Note**
 >
@@ -382,7 +382,7 @@ func main() {
 |--|--|
 | [`assertions.JSONEqT[EDoc, ADoc RText](t T, expected EDoc, actual ADoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#JSONEqT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONEqT](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L91)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONEqT](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L90)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -511,7 +511,7 @@ type dummyStruct struct {
 |--|--|
 | [`assertions.JSONMarshalAsT[EDoc RText](t T, expected EDoc, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#JSONMarshalAsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONMarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L162)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONMarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L161)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -642,7 +642,7 @@ type dummyStruct struct {
 |--|--|
 | [`assertions.JSONUnmarshalAsT[Object any, ADoc RText](t T, expected Object, jazon ADoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#JSONUnmarshalAsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONUnmarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L125)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#JSONUnmarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/json.go#L124)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/docs/doc-site/api/yaml.md
+++ b/docs/doc-site/api/yaml.md
@@ -77,7 +77,7 @@ See [YAMLEqBytes](https://pkg.go.dev/github.com/go-openapi/testify/v2/assert#YAM
 |--|--|
 | [`assertions.YAMLEq(t T, expected string, actual string, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#YAMLEq) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLEq](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L79)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLEq](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L78)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -148,7 +148,7 @@ For dynamic redaction of the input text via a callback, use [YAMLEqT](https://pk
 |--|--|
 | [`assertions.YAMLEqBytes(t T, expected []byte, actual []byte, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#YAMLEqBytes) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLEqBytes](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L48)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLEqBytes](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L47)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -192,7 +192,7 @@ NOTE: passed values (expected, actual) may be wrapped as functions to redact the
 |--|--|
 | [`assertions.YAMLEqT[EDoc, ADoc RText](t T, expected EDoc, actual ADoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#YAMLEqT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLEqT](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L100)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLEqT](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L99)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -247,7 +247,7 @@ NOTE: passed expected value may be wrapped as a function to redact the input tex
 |--|--|
 | [`assertions.YAMLMarshalAsT[EDoc RText](t T, expected EDoc, object any, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#YAMLMarshalAsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLMarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L171)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLMarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L170)
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -304,7 +304,7 @@ NOTE: passed yamlDoc value may be wrapped as a function to redact the input text
 |--|--|
 | [`assertions.YAMLUnmarshalAsT[Object any, ADoc RText](t T, expected Object, yamlDoc ADoc, msgAndArgs ...any) bool`](https://pkg.go.dev/github.com/go-openapi/testify/v2/internal/assertions#YAMLUnmarshalAsT) | internal implementation |
 
-**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLUnmarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L134)
+**Source:** [github.com/go-openapi/testify/v2/internal/assertions#YAMLUnmarshalAsT](https://github.com/go-openapi/testify/blob/master/internal/assertions/yaml.go#L133)
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/internal/assertions/diff.go
+++ b/internal/assertions/diff.go
@@ -67,7 +67,7 @@ func typeAndKind(v any) (reflect.Type, reflect.Kind) {
 
 	k := t.Kind()
 
-	if k == reflect.Ptr {
+	if k == reflect.Pointer {
 		t = t.Elem()
 		k = t.Kind()
 	}

--- a/internal/assertions/equal_unary.go
+++ b/internal/assertions/equal_unary.go
@@ -121,7 +121,7 @@ func isNil(object any) bool {
 	case
 		reflect.Chan, reflect.Func,
 		reflect.Interface, reflect.Map,
-		reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
 
 		return value.IsNil()
 	default:
@@ -151,7 +151,7 @@ func isEmptyValue(objValue reflect.Value) bool {
 	case reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
 	// non-nil pointers are empty if the value they point to is empty
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return isEmptyValue(objValue.Elem())
 	default:
 		return false

--- a/internal/assertions/type_test.go
+++ b/internal/assertions/type_test.go
@@ -288,7 +288,7 @@ func kindCases() iter.Seq[kindCase] {
 		{reflect.Float64, 0.0345, true, "is float64"},
 		{reflect.Map, make(map[string]int), true, "is map"},
 		{reflect.Bool, true, true, "is bool"},
-		{reflect.Ptr, new(int), true, "is pointer"},
+		{reflect.Pointer, new(int), true, "is pointer"},
 		// False cases
 		{reflect.String, 13, false, "not string"},
 		{reflect.Int, [6]int{2, 3, 5, 7, 11, 13}, false, "not int"},
@@ -297,13 +297,13 @@ func kindCases() iter.Seq[kindCase] {
 		// Edge cases
 		// True
 		{reflect.Invalid, any(nil), true, "legitimate expectation of reflect.Invalid (any)"},
-		{reflect.Ptr, (*any)(nil), true, "legitimate expectation of reflect.Pointer (*any)"},
+		{reflect.Pointer, (*any)(nil), true, "legitimate expectation of reflect.Pointer (*any)"},
 		{reflect.Invalid, (error)(nil), true, "legitimate expectation of reflect.Invalid (error)"},
 		{reflect.Invalid, nil, true, "legitimate nil input"},
 		// False
 		{reflect.Interface, iface, false, "interface returns concrete type (any)"},
 		{reflect.Interface, errors.New("stuff"), false, "interface returns concrete type (error)"},
 		{reflect.Invalid, "string", false, "wrong expectation of reflect.Invalid"},
-		{reflect.Ptr, nil, false, "nil input"},
+		{reflect.Pointer, nil, false, "nil input"},
 	})
 }

--- a/require/require_format.go
+++ b/require/require_format.go
@@ -22,7 +22,7 @@ func Blockedf(t T, ch any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Blocked(t, ch, forwardArgs(msg, args)) {
+	if assertions.Blocked(t, ch, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -36,7 +36,7 @@ func BlockedTf[E any, CHAN ~chan E](t T, ch CHAN, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.BlockedT[E, CHAN](t, ch, forwardArgs(msg, args)) {
+	if assertions.BlockedT[E, CHAN](t, ch, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -50,7 +50,7 @@ func Conditionf(t T, comp func() bool, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Condition(t, comp, forwardArgs(msg, args)) {
+	if assertions.Condition(t, comp, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -64,7 +64,7 @@ func Consistentlyf[C Conditioner](t T, condition C, timeout time.Duration, tick 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Consistently[C](t, condition, timeout, tick, forwardArgs(msg, args)) {
+	if assertions.Consistently[C](t, condition, timeout, tick, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -78,7 +78,7 @@ func Containsf(t T, s any, contains any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Contains(t, s, contains, forwardArgs(msg, args)) {
+	if assertions.Contains(t, s, contains, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -92,7 +92,7 @@ func DirExistsf(t T, path string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.DirExists(t, path, forwardArgs(msg, args)) {
+	if assertions.DirExists(t, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -106,7 +106,7 @@ func DirNotExistsf(t T, path string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.DirNotExists(t, path, forwardArgs(msg, args)) {
+	if assertions.DirNotExists(t, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -120,7 +120,7 @@ func ElementsMatchf(t T, listA any, listB any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.ElementsMatch(t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.ElementsMatch(t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -134,7 +134,7 @@ func ElementsMatchTf[E comparable](t T, listA []E, listB []E, msg string, args .
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.ElementsMatchT[E](t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.ElementsMatchT[E](t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -148,7 +148,7 @@ func Emptyf(t T, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Empty(t, object, forwardArgs(msg, args)) {
+	if assertions.Empty(t, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -162,7 +162,7 @@ func Equalf(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Equal(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.Equal(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -176,7 +176,7 @@ func EqualErrorf(t T, err error, errString string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualError(t, err, errString, forwardArgs(msg, args)) {
+	if assertions.EqualError(t, err, errString, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -190,7 +190,7 @@ func EqualExportedValuesf(t T, expected any, actual any, msg string, args ...any
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualExportedValues(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.EqualExportedValues(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -204,7 +204,7 @@ func EqualTf[V comparable](t T, expected V, actual V, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualT[V](t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.EqualT[V](t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -218,7 +218,7 @@ func EqualValuesf(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualValues(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.EqualValues(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -232,7 +232,7 @@ func Errorf(t T, err error, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Error(t, err, forwardArgs(msg, args)) {
+	if assertions.Error(t, err, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -246,7 +246,7 @@ func ErrorAsf(t T, err error, target any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.ErrorAs(t, err, target, forwardArgs(msg, args)) {
+	if assertions.ErrorAs(t, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -260,7 +260,7 @@ func ErrorContainsf(t T, err error, contains string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.ErrorContains(t, err, contains, forwardArgs(msg, args)) {
+	if assertions.ErrorContains(t, err, contains, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -274,7 +274,7 @@ func ErrorIsf(t T, err error, target error, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.ErrorIs(t, err, target, forwardArgs(msg, args)) {
+	if assertions.ErrorIs(t, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -288,7 +288,7 @@ func Eventuallyf[C Conditioner](t T, condition C, timeout time.Duration, tick ti
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Eventually[C](t, condition, timeout, tick, forwardArgs(msg, args)) {
+	if assertions.Eventually[C](t, condition, timeout, tick, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -302,7 +302,7 @@ func EventuallyWithf[C CollectibleConditioner](t T, condition C, timeout time.Du
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.EventuallyWith[C](t, condition, timeout, tick, forwardArgs(msg, args)) {
+	if assertions.EventuallyWith[C](t, condition, timeout, tick, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -316,7 +316,7 @@ func Exactlyf(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Exactly(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.Exactly(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -330,7 +330,7 @@ func Failf(t T, failureMessage string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	_ = assertions.Fail(t, failureMessage, forwardArgs(msg, args))
+	_ = assertions.Fail(t, failureMessage, forwardArgs(msg, args)...)
 
 	t.FailNow()
 }
@@ -342,7 +342,7 @@ func FailNowf(t T, failureMessage string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	_ = assertions.FailNow(t, failureMessage, forwardArgs(msg, args))
+	_ = assertions.FailNow(t, failureMessage, forwardArgs(msg, args)...)
 
 	t.FailNow()
 }
@@ -354,7 +354,7 @@ func Falsef(t T, value bool, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.False(t, value, forwardArgs(msg, args)) {
+	if assertions.False(t, value, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -368,7 +368,7 @@ func FalseTf[B Boolean](t T, value B, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.FalseT[B](t, value, forwardArgs(msg, args)) {
+	if assertions.FalseT[B](t, value, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -382,7 +382,7 @@ func FileEmptyf(t T, path string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileEmpty(t, path, forwardArgs(msg, args)) {
+	if assertions.FileEmpty(t, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -396,7 +396,7 @@ func FileExistsf(t T, path string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileExists(t, path, forwardArgs(msg, args)) {
+	if assertions.FileExists(t, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -410,7 +410,7 @@ func FileNotEmptyf(t T, path string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileNotEmpty(t, path, forwardArgs(msg, args)) {
+	if assertions.FileNotEmpty(t, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -424,7 +424,7 @@ func FileNotExistsf(t T, path string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileNotExists(t, path, forwardArgs(msg, args)) {
+	if assertions.FileNotExists(t, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -438,7 +438,7 @@ func Greaterf(t T, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Greater(t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.Greater(t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -452,7 +452,7 @@ func GreaterOrEqualf(t T, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.GreaterOrEqual(t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.GreaterOrEqual(t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -466,7 +466,7 @@ func GreaterOrEqualTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg st
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.GreaterOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.GreaterOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -480,7 +480,7 @@ func GreaterTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg string, a
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.GreaterT[Orderable](t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.GreaterT[Orderable](t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -494,7 +494,7 @@ func HTTPBodyContainsf(t T, handler http.HandlerFunc, method string, url string,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPBodyContains(t, handler, method, url, values, str, forwardArgs(msg, args)) {
+	if assertions.HTTPBodyContains(t, handler, method, url, values, str, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -508,7 +508,7 @@ func HTTPBodyNotContainsf(t T, handler http.HandlerFunc, method string, url stri
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPBodyNotContains(t, handler, method, url, values, str, forwardArgs(msg, args)) {
+	if assertions.HTTPBodyNotContains(t, handler, method, url, values, str, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -522,7 +522,7 @@ func HTTPErrorf(t T, handler http.HandlerFunc, method string, url string, values
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPError(t, handler, method, url, values, forwardArgs(msg, args)) {
+	if assertions.HTTPError(t, handler, method, url, values, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -536,7 +536,7 @@ func HTTPRedirectf(t T, handler http.HandlerFunc, method string, url string, val
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPRedirect(t, handler, method, url, values, forwardArgs(msg, args)) {
+	if assertions.HTTPRedirect(t, handler, method, url, values, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -550,7 +550,7 @@ func HTTPStatusCodef(t T, handler http.HandlerFunc, method string, url string, v
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPStatusCode(t, handler, method, url, values, statuscode, forwardArgs(msg, args)) {
+	if assertions.HTTPStatusCode(t, handler, method, url, values, statuscode, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -564,7 +564,7 @@ func HTTPSuccessf(t T, handler http.HandlerFunc, method string, url string, valu
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPSuccess(t, handler, method, url, values, forwardArgs(msg, args)) {
+	if assertions.HTTPSuccess(t, handler, method, url, values, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -578,7 +578,7 @@ func Implementsf(t T, interfaceObject any, object any, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Implements(t, interfaceObject, object, forwardArgs(msg, args)) {
+	if assertions.Implements(t, interfaceObject, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -592,7 +592,7 @@ func InDeltaf(t T, expected any, actual any, delta float64, msg string, args ...
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDelta(t, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDelta(t, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -606,7 +606,7 @@ func InDeltaMapValuesf(t T, expected any, actual any, delta float64, msg string,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDeltaMapValues(t, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDeltaMapValues(t, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -620,7 +620,7 @@ func InDeltaSlicef(t T, expected any, actual any, delta float64, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDeltaSlice(t, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDeltaSlice(t, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -634,7 +634,7 @@ func InDeltaTf[Number Measurable](t T, expected Number, actual Number, delta Num
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDeltaT[Number](t, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDeltaT[Number](t, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -648,7 +648,7 @@ func InEpsilonf(t T, expected any, actual any, epsilon float64, msg string, args
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilon(t, expected, actual, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilon(t, expected, actual, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -662,7 +662,7 @@ func InEpsilonSlicef(t T, expected any, actual any, epsilon float64, msg string,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilonSlice(t, expected, actual, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilonSlice(t, expected, actual, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -676,7 +676,7 @@ func InEpsilonSymmetricf(t T, x any, y any, epsilon float64, msg string, args ..
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilonSymmetric(t, x, y, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilonSymmetric(t, x, y, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -690,7 +690,7 @@ func InEpsilonSymmetricTf[Number Measurable](t T, x Number, y Number, epsilon fl
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilonSymmetricT[Number](t, x, y, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilonSymmetricT[Number](t, x, y, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -704,7 +704,7 @@ func InEpsilonTf[Number Measurable](t T, expected Number, actual Number, epsilon
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilonT[Number](t, expected, actual, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilonT[Number](t, expected, actual, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -718,7 +718,7 @@ func IsDecreasingf(t T, collection any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsDecreasing(t, collection, forwardArgs(msg, args)) {
+	if assertions.IsDecreasing(t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -732,7 +732,7 @@ func IsDecreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)) {
+	if assertions.IsDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -746,7 +746,7 @@ func IsIncreasingf(t T, collection any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsIncreasing(t, collection, forwardArgs(msg, args)) {
+	if assertions.IsIncreasing(t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -760,7 +760,7 @@ func IsIncreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)) {
+	if assertions.IsIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -774,7 +774,7 @@ func IsNonDecreasingf(t T, collection any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNonDecreasing(t, collection, forwardArgs(msg, args)) {
+	if assertions.IsNonDecreasing(t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -788,7 +788,7 @@ func IsNonDecreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlic
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNonDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)) {
+	if assertions.IsNonDecreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -802,7 +802,7 @@ func IsNonIncreasingf(t T, collection any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNonIncreasing(t, collection, forwardArgs(msg, args)) {
+	if assertions.IsNonIncreasing(t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -816,7 +816,7 @@ func IsNonIncreasingTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlic
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNonIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)) {
+	if assertions.IsNonIncreasingT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -830,7 +830,7 @@ func IsNotOfTypeTf[EType any](t T, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNotOfTypeT[EType](t, object, forwardArgs(msg, args)) {
+	if assertions.IsNotOfTypeT[EType](t, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -844,7 +844,7 @@ func IsNotTypef(t T, theType any, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNotType(t, theType, object, forwardArgs(msg, args)) {
+	if assertions.IsNotType(t, theType, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -858,7 +858,7 @@ func IsOfTypeTf[EType any](t T, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsOfTypeT[EType](t, object, forwardArgs(msg, args)) {
+	if assertions.IsOfTypeT[EType](t, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -872,7 +872,7 @@ func IsTypef(t T, expectedType any, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsType(t, expectedType, object, forwardArgs(msg, args)) {
+	if assertions.IsType(t, expectedType, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -886,7 +886,7 @@ func JSONEqf(t T, expected string, actual string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONEq(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.JSONEq(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -900,7 +900,7 @@ func JSONEqBytesf(t T, expected []byte, actual []byte, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONEqBytes(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.JSONEqBytes(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -914,7 +914,7 @@ func JSONEqTf[EDoc, ADoc RText](t T, expected EDoc, actual ADoc, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.JSONEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -928,7 +928,7 @@ func JSONMarshalAsTf[EDoc RText](t T, expected EDoc, object any, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args)) {
+	if assertions.JSONMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -942,7 +942,7 @@ func JSONUnmarshalAsTf[Object any, ADoc RText](t T, expected Object, jazon ADoc,
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONUnmarshalAsT[Object, ADoc](t, expected, jazon, forwardArgs(msg, args)) {
+	if assertions.JSONUnmarshalAsT[Object, ADoc](t, expected, jazon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -956,7 +956,7 @@ func Kindf(t T, expectedKind reflect.Kind, object any, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Kind(t, expectedKind, object, forwardArgs(msg, args)) {
+	if assertions.Kind(t, expectedKind, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -970,7 +970,7 @@ func Lenf(t T, object any, length int, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Len(t, object, length, forwardArgs(msg, args)) {
+	if assertions.Len(t, object, length, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -984,7 +984,7 @@ func Lessf(t T, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Less(t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.Less(t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -998,7 +998,7 @@ func LessOrEqualf(t T, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.LessOrEqual(t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.LessOrEqual(t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1012,7 +1012,7 @@ func LessOrEqualTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg strin
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.LessOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.LessOrEqualT[Orderable](t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1026,7 +1026,7 @@ func LessTf[Orderable Ordered](t T, e1 Orderable, e2 Orderable, msg string, args
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.LessT[Orderable](t, e1, e2, forwardArgs(msg, args)) {
+	if assertions.LessT[Orderable](t, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1040,7 +1040,7 @@ func MapContainsTf[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msg str
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.MapContainsT[Map, K, V](t, m, key, forwardArgs(msg, args)) {
+	if assertions.MapContainsT[Map, K, V](t, m, key, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1054,7 +1054,7 @@ func MapEqualTf[K, V comparable](t T, listA map[K]V, listB map[K]V, msg string, 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.MapEqualT[K, V](t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.MapEqualT[K, V](t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1068,7 +1068,7 @@ func MapNotContainsTf[Map ~map[K]V, K comparable, V any](t T, m Map, key K, msg 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.MapNotContainsT[Map, K, V](t, m, key, forwardArgs(msg, args)) {
+	if assertions.MapNotContainsT[Map, K, V](t, m, key, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1082,7 +1082,7 @@ func MapNotEqualTf[K, V comparable](t T, listA map[K]V, listB map[K]V, msg strin
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.MapNotEqualT[K, V](t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.MapNotEqualT[K, V](t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1096,7 +1096,7 @@ func Negativef(t T, e any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Negative(t, e, forwardArgs(msg, args)) {
+	if assertions.Negative(t, e, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1110,7 +1110,7 @@ func NegativeTf[SignedNumber SignedNumeric](t T, e SignedNumber, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NegativeT[SignedNumber](t, e, forwardArgs(msg, args)) {
+	if assertions.NegativeT[SignedNumber](t, e, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1124,7 +1124,7 @@ func Neverf[C NeverConditioner](t T, condition C, timeout time.Duration, tick ti
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Never[C](t, condition, timeout, tick, forwardArgs(msg, args)) {
+	if assertions.Never[C](t, condition, timeout, tick, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1138,7 +1138,7 @@ func Nilf(t T, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Nil(t, object, forwardArgs(msg, args)) {
+	if assertions.Nil(t, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1152,7 +1152,7 @@ func NoErrorf(t T, err error, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NoError(t, err, forwardArgs(msg, args)) {
+	if assertions.NoError(t, err, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1166,7 +1166,7 @@ func NoFileDescriptorLeakf(t T, tested func(), msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NoFileDescriptorLeak(t, tested, forwardArgs(msg, args)) {
+	if assertions.NoFileDescriptorLeak(t, tested, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1180,7 +1180,7 @@ func NoGoRoutineLeakf(t T, tested func(), msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NoGoRoutineLeak(t, tested, forwardArgs(msg, args)) {
+	if assertions.NoGoRoutineLeak(t, tested, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1194,7 +1194,7 @@ func NotBlockedf(t T, ch any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotBlocked(t, ch, forwardArgs(msg, args)) {
+	if assertions.NotBlocked(t, ch, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1208,7 +1208,7 @@ func NotBlockedTf[E any, CHAN ~chan E](t T, ch CHAN, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotBlockedT[E, CHAN](t, ch, forwardArgs(msg, args)) {
+	if assertions.NotBlockedT[E, CHAN](t, ch, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1222,7 +1222,7 @@ func NotContainsf(t T, s any, contains any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotContains(t, s, contains, forwardArgs(msg, args)) {
+	if assertions.NotContains(t, s, contains, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1236,7 +1236,7 @@ func NotElementsMatchf(t T, listA any, listB any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotElementsMatch(t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.NotElementsMatch(t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1250,7 +1250,7 @@ func NotElementsMatchTf[E comparable](t T, listA []E, listB []E, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotElementsMatchT[E](t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.NotElementsMatchT[E](t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1264,7 +1264,7 @@ func NotEmptyf(t T, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEmpty(t, object, forwardArgs(msg, args)) {
+	if assertions.NotEmpty(t, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1278,7 +1278,7 @@ func NotEqualf(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEqual(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotEqual(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1292,7 +1292,7 @@ func NotEqualTf[V comparable](t T, expected V, actual V, msg string, args ...any
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEqualT[V](t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotEqualT[V](t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1306,7 +1306,7 @@ func NotEqualValuesf(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEqualValues(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotEqualValues(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1320,7 +1320,7 @@ func NotErrorAsf(t T, err error, target any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotErrorAs(t, err, target, forwardArgs(msg, args)) {
+	if assertions.NotErrorAs(t, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1334,7 +1334,7 @@ func NotErrorIsf(t T, err error, target error, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotErrorIs(t, err, target, forwardArgs(msg, args)) {
+	if assertions.NotErrorIs(t, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1348,7 +1348,7 @@ func NotImplementsf(t T, interfaceObject any, object any, msg string, args ...an
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotImplements(t, interfaceObject, object, forwardArgs(msg, args)) {
+	if assertions.NotImplements(t, interfaceObject, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1362,7 +1362,7 @@ func NotKindf(t T, expectedKind reflect.Kind, object any, msg string, args ...an
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotKind(t, expectedKind, object, forwardArgs(msg, args)) {
+	if assertions.NotKind(t, expectedKind, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1376,7 +1376,7 @@ func NotNilf(t T, object any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotNil(t, object, forwardArgs(msg, args)) {
+	if assertions.NotNil(t, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1390,7 +1390,7 @@ func NotPanicsf(t T, f func(), msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotPanics(t, f, forwardArgs(msg, args)) {
+	if assertions.NotPanics(t, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1404,7 +1404,7 @@ func NotRegexpf(t T, rx any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotRegexp(t, rx, actual, forwardArgs(msg, args)) {
+	if assertions.NotRegexp(t, rx, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1418,7 +1418,7 @@ func NotRegexpTf[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msg string, ar
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotRegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args)) {
+	if assertions.NotRegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1432,7 +1432,7 @@ func NotSamef(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotSame(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotSame(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1446,7 +1446,7 @@ func NotSameTf[P any](t T, expected *P, actual *P, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotSameT[P](t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotSameT[P](t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1460,7 +1460,7 @@ func NotSortedTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotSortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args)) {
+	if assertions.NotSortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1474,7 +1474,7 @@ func NotSubsetf(t T, list any, subset any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotSubset(t, list, subset, forwardArgs(msg, args)) {
+	if assertions.NotSubset(t, list, subset, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1488,7 +1488,7 @@ func NotZerof(t T, i any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotZero(t, i, forwardArgs(msg, args)) {
+	if assertions.NotZero(t, i, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1502,7 +1502,7 @@ func Panicsf(t T, f func(), msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Panics(t, f, forwardArgs(msg, args)) {
+	if assertions.Panics(t, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1516,7 +1516,7 @@ func PanicsWithErrorf(t T, errString string, f func(), msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.PanicsWithError(t, errString, f, forwardArgs(msg, args)) {
+	if assertions.PanicsWithError(t, errString, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1530,7 +1530,7 @@ func PanicsWithValuef(t T, expected any, f func(), msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.PanicsWithValue(t, expected, f, forwardArgs(msg, args)) {
+	if assertions.PanicsWithValue(t, expected, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1544,7 +1544,7 @@ func Positivef(t T, e any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Positive(t, e, forwardArgs(msg, args)) {
+	if assertions.Positive(t, e, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1558,7 +1558,7 @@ func PositiveTf[SignedNumber SignedNumeric](t T, e SignedNumber, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.PositiveT[SignedNumber](t, e, forwardArgs(msg, args)) {
+	if assertions.PositiveT[SignedNumber](t, e, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1572,7 +1572,7 @@ func Regexpf(t T, rx any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Regexp(t, rx, actual, forwardArgs(msg, args)) {
+	if assertions.Regexp(t, rx, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1586,7 +1586,7 @@ func RegexpTf[Rex RegExp, ADoc Text](t T, rx Rex, actual ADoc, msg string, args 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.RegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args)) {
+	if assertions.RegexpT[Rex, ADoc](t, rx, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1600,7 +1600,7 @@ func Samef(t T, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Same(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.Same(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1614,7 +1614,7 @@ func SameTf[P any](t T, expected *P, actual *P, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SameT[P](t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.SameT[P](t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1628,7 +1628,7 @@ func SeqContainsTf[E comparable](t T, iter iter.Seq[E], element E, msg string, a
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SeqContainsT[E](t, iter, element, forwardArgs(msg, args)) {
+	if assertions.SeqContainsT[E](t, iter, element, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1642,7 +1642,7 @@ func SeqNotContainsTf[E comparable](t T, iter iter.Seq[E], element E, msg string
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SeqNotContainsT[E](t, iter, element, forwardArgs(msg, args)) {
+	if assertions.SeqNotContainsT[E](t, iter, element, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1656,7 +1656,7 @@ func SliceContainsTf[Slice ~[]E, E comparable](t T, s Slice, element E, msg stri
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SliceContainsT[Slice, E](t, s, element, forwardArgs(msg, args)) {
+	if assertions.SliceContainsT[Slice, E](t, s, element, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1670,7 +1670,7 @@ func SliceEqualTf[E comparable](t T, listA []E, listB []E, msg string, args ...a
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SliceEqualT[E](t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.SliceEqualT[E](t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1684,7 +1684,7 @@ func SliceNotContainsTf[Slice ~[]E, E comparable](t T, s Slice, element E, msg s
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SliceNotContainsT[Slice, E](t, s, element, forwardArgs(msg, args)) {
+	if assertions.SliceNotContainsT[Slice, E](t, s, element, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1698,7 +1698,7 @@ func SliceNotEqualTf[E comparable](t T, listA []E, listB []E, msg string, args .
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SliceNotEqualT[E](t, listA, listB, forwardArgs(msg, args)) {
+	if assertions.SliceNotEqualT[E](t, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1712,7 +1712,7 @@ func SliceNotSubsetTf[Slice ~[]E, E comparable](t T, list Slice, subset Slice, m
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SliceNotSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args)) {
+	if assertions.SliceNotSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1726,7 +1726,7 @@ func SliceSubsetTf[Slice ~[]E, E comparable](t T, list Slice, subset Slice, msg 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SliceSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args)) {
+	if assertions.SliceSubsetT[Slice, E](t, list, subset, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1740,7 +1740,7 @@ func SortedTf[OrderedSlice ~[]E, E Ordered](t T, collection OrderedSlice, msg st
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.SortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args)) {
+	if assertions.SortedT[OrderedSlice, E](t, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1754,7 +1754,7 @@ func StringContainsTf[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msg string
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.StringContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args)) {
+	if assertions.StringContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1768,7 +1768,7 @@ func StringNotContainsTf[ADoc, EDoc Text](t T, str ADoc, substring EDoc, msg str
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.StringNotContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args)) {
+	if assertions.StringNotContainsT[ADoc, EDoc](t, str, substring, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1782,7 +1782,7 @@ func Subsetf(t T, list any, subset any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Subset(t, list, subset, forwardArgs(msg, args)) {
+	if assertions.Subset(t, list, subset, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1796,7 +1796,7 @@ func Truef(t T, value bool, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.True(t, value, forwardArgs(msg, args)) {
+	if assertions.True(t, value, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1810,7 +1810,7 @@ func TrueTf[B Boolean](t T, value B, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.TrueT[B](t, value, forwardArgs(msg, args)) {
+	if assertions.TrueT[B](t, value, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1824,7 +1824,7 @@ func WithinDurationf(t T, expected time.Time, actual time.Time, delta time.Durat
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.WithinDuration(t, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.WithinDuration(t, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1838,7 +1838,7 @@ func WithinRangef(t T, actual time.Time, start time.Time, end time.Time, msg str
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.WithinRange(t, actual, start, end, forwardArgs(msg, args)) {
+	if assertions.WithinRange(t, actual, start, end, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1852,7 +1852,7 @@ func YAMLEqf(t T, expected string, actual string, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLEq(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.YAMLEq(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1866,7 +1866,7 @@ func YAMLEqBytesf(t T, expected []byte, actual []byte, msg string, args ...any) 
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLEqBytes(t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.YAMLEqBytes(t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1880,7 +1880,7 @@ func YAMLEqTf[EDoc, ADoc RText](t T, expected EDoc, actual ADoc, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args)) {
+	if assertions.YAMLEqT[EDoc, ADoc](t, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1894,7 +1894,7 @@ func YAMLMarshalAsTf[EDoc RText](t T, expected EDoc, object any, msg string, arg
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args)) {
+	if assertions.YAMLMarshalAsT[EDoc](t, expected, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1908,7 +1908,7 @@ func YAMLUnmarshalAsTf[Object any, ADoc RText](t T, expected Object, yamlDoc ADo
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLUnmarshalAsT[Object, ADoc](t, expected, yamlDoc, forwardArgs(msg, args)) {
+	if assertions.YAMLUnmarshalAsT[Object, ADoc](t, expected, yamlDoc, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1922,7 +1922,7 @@ func Zerof(t T, i any, msg string, args ...any) {
 	if h, ok := t.(H); ok {
 		h.Helper()
 	}
-	if assertions.Zero(t, i, forwardArgs(msg, args)) {
+	if assertions.Zero(t, i, forwardArgs(msg, args)...) {
 		return
 	}
 

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -51,7 +51,7 @@ func (a *Assertions) Blockedf(ch any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Blocked(a.T, ch, forwardArgs(msg, args)) {
+	if assertions.Blocked(a.T, ch, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -79,7 +79,7 @@ func (a *Assertions) Conditionf(comp func() bool, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Condition(a.T, comp, forwardArgs(msg, args)) {
+	if assertions.Condition(a.T, comp, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -107,7 +107,7 @@ func (a *Assertions) Containsf(s any, contains any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Contains(a.T, s, contains, forwardArgs(msg, args)) {
+	if assertions.Contains(a.T, s, contains, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -135,7 +135,7 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.DirExists(a.T, path, forwardArgs(msg, args)) {
+	if assertions.DirExists(a.T, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -163,7 +163,7 @@ func (a *Assertions) DirNotExistsf(path string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.DirNotExists(a.T, path, forwardArgs(msg, args)) {
+	if assertions.DirNotExists(a.T, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -191,7 +191,7 @@ func (a *Assertions) ElementsMatchf(listA any, listB any, msg string, args ...an
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.ElementsMatch(a.T, listA, listB, forwardArgs(msg, args)) {
+	if assertions.ElementsMatch(a.T, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -219,7 +219,7 @@ func (a *Assertions) Emptyf(object any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Empty(a.T, object, forwardArgs(msg, args)) {
+	if assertions.Empty(a.T, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -247,7 +247,7 @@ func (a *Assertions) Equalf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Equal(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.Equal(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -275,7 +275,7 @@ func (a *Assertions) EqualErrorf(err error, errString string, msg string, args .
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualError(a.T, err, errString, forwardArgs(msg, args)) {
+	if assertions.EqualError(a.T, err, errString, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -303,7 +303,7 @@ func (a *Assertions) EqualExportedValuesf(expected any, actual any, msg string, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualExportedValues(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.EqualExportedValues(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -331,7 +331,7 @@ func (a *Assertions) EqualValuesf(expected any, actual any, msg string, args ...
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.EqualValues(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.EqualValues(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -359,7 +359,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Error(a.T, err, forwardArgs(msg, args)) {
+	if assertions.Error(a.T, err, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -387,7 +387,7 @@ func (a *Assertions) ErrorAsf(err error, target any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.ErrorAs(a.T, err, target, forwardArgs(msg, args)) {
+	if assertions.ErrorAs(a.T, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -415,7 +415,7 @@ func (a *Assertions) ErrorContainsf(err error, contains string, msg string, args
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.ErrorContains(a.T, err, contains, forwardArgs(msg, args)) {
+	if assertions.ErrorContains(a.T, err, contains, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -443,7 +443,7 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...any) 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.ErrorIs(a.T, err, target, forwardArgs(msg, args)) {
+	if assertions.ErrorIs(a.T, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -471,7 +471,7 @@ func (a *Assertions) Exactlyf(expected any, actual any, msg string, args ...any)
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Exactly(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.Exactly(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -497,7 +497,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	_ = assertions.Fail(a.T, failureMessage, forwardArgs(msg, args))
+	_ = assertions.Fail(a.T, failureMessage, forwardArgs(msg, args)...)
 
 	a.T.FailNow()
 }
@@ -521,7 +521,7 @@ func (a *Assertions) FailNowf(failureMessage string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	_ = assertions.FailNow(a.T, failureMessage, forwardArgs(msg, args))
+	_ = assertions.FailNow(a.T, failureMessage, forwardArgs(msg, args)...)
 
 	a.T.FailNow()
 }
@@ -547,7 +547,7 @@ func (a *Assertions) Falsef(value bool, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.False(a.T, value, forwardArgs(msg, args)) {
+	if assertions.False(a.T, value, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -575,7 +575,7 @@ func (a *Assertions) FileEmptyf(path string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileEmpty(a.T, path, forwardArgs(msg, args)) {
+	if assertions.FileEmpty(a.T, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -603,7 +603,7 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileExists(a.T, path, forwardArgs(msg, args)) {
+	if assertions.FileExists(a.T, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -631,7 +631,7 @@ func (a *Assertions) FileNotEmptyf(path string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileNotEmpty(a.T, path, forwardArgs(msg, args)) {
+	if assertions.FileNotEmpty(a.T, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -659,7 +659,7 @@ func (a *Assertions) FileNotExistsf(path string, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.FileNotExists(a.T, path, forwardArgs(msg, args)) {
+	if assertions.FileNotExists(a.T, path, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -687,7 +687,7 @@ func (a *Assertions) Greaterf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Greater(a.T, e1, e2, forwardArgs(msg, args)) {
+	if assertions.Greater(a.T, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -715,7 +715,7 @@ func (a *Assertions) GreaterOrEqualf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.GreaterOrEqual(a.T, e1, e2, forwardArgs(msg, args)) {
+	if assertions.GreaterOrEqual(a.T, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -743,7 +743,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPBodyContains(a.T, handler, method, url, values, str, forwardArgs(msg, args)) {
+	if assertions.HTTPBodyContains(a.T, handler, method, url, values, str, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -771,7 +771,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPBodyNotContains(a.T, handler, method, url, values, str, forwardArgs(msg, args)) {
+	if assertions.HTTPBodyNotContains(a.T, handler, method, url, values, str, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -799,7 +799,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPError(a.T, handler, method, url, values, forwardArgs(msg, args)) {
+	if assertions.HTTPError(a.T, handler, method, url, values, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -827,7 +827,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPRedirect(a.T, handler, method, url, values, forwardArgs(msg, args)) {
+	if assertions.HTTPRedirect(a.T, handler, method, url, values, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -855,7 +855,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPStatusCode(a.T, handler, method, url, values, statuscode, forwardArgs(msg, args)) {
+	if assertions.HTTPStatusCode(a.T, handler, method, url, values, statuscode, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -883,7 +883,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.HTTPSuccess(a.T, handler, method, url, values, forwardArgs(msg, args)) {
+	if assertions.HTTPSuccess(a.T, handler, method, url, values, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -911,7 +911,7 @@ func (a *Assertions) Implementsf(interfaceObject any, object any, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Implements(a.T, interfaceObject, object, forwardArgs(msg, args)) {
+	if assertions.Implements(a.T, interfaceObject, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -939,7 +939,7 @@ func (a *Assertions) InDeltaf(expected any, actual any, delta float64, msg strin
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDelta(a.T, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDelta(a.T, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -967,7 +967,7 @@ func (a *Assertions) InDeltaMapValuesf(expected any, actual any, delta float64, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDeltaMapValues(a.T, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDeltaMapValues(a.T, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -995,7 +995,7 @@ func (a *Assertions) InDeltaSlicef(expected any, actual any, delta float64, msg 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.InDeltaSlice(a.T, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.InDeltaSlice(a.T, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1023,7 +1023,7 @@ func (a *Assertions) InEpsilonf(expected any, actual any, epsilon float64, msg s
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilon(a.T, expected, actual, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilon(a.T, expected, actual, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1051,7 +1051,7 @@ func (a *Assertions) InEpsilonSlicef(expected any, actual any, epsilon float64, 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilonSlice(a.T, expected, actual, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilonSlice(a.T, expected, actual, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1079,7 +1079,7 @@ func (a *Assertions) InEpsilonSymmetricf(x any, y any, epsilon float64, msg stri
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.InEpsilonSymmetric(a.T, x, y, epsilon, forwardArgs(msg, args)) {
+	if assertions.InEpsilonSymmetric(a.T, x, y, epsilon, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1107,7 +1107,7 @@ func (a *Assertions) IsDecreasingf(collection any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsDecreasing(a.T, collection, forwardArgs(msg, args)) {
+	if assertions.IsDecreasing(a.T, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1135,7 +1135,7 @@ func (a *Assertions) IsIncreasingf(collection any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsIncreasing(a.T, collection, forwardArgs(msg, args)) {
+	if assertions.IsIncreasing(a.T, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1163,7 +1163,7 @@ func (a *Assertions) IsNonDecreasingf(collection any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNonDecreasing(a.T, collection, forwardArgs(msg, args)) {
+	if assertions.IsNonDecreasing(a.T, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1191,7 +1191,7 @@ func (a *Assertions) IsNonIncreasingf(collection any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNonIncreasing(a.T, collection, forwardArgs(msg, args)) {
+	if assertions.IsNonIncreasing(a.T, collection, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1219,7 +1219,7 @@ func (a *Assertions) IsNotTypef(theType any, object any, msg string, args ...any
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsNotType(a.T, theType, object, forwardArgs(msg, args)) {
+	if assertions.IsNotType(a.T, theType, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1247,7 +1247,7 @@ func (a *Assertions) IsTypef(expectedType any, object any, msg string, args ...a
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.IsType(a.T, expectedType, object, forwardArgs(msg, args)) {
+	if assertions.IsType(a.T, expectedType, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1275,7 +1275,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONEq(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.JSONEq(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1303,7 +1303,7 @@ func (a *Assertions) JSONEqBytesf(expected []byte, actual []byte, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.JSONEqBytes(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.JSONEqBytes(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1331,7 +1331,7 @@ func (a *Assertions) Kindf(expectedKind reflect.Kind, object any, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Kind(a.T, expectedKind, object, forwardArgs(msg, args)) {
+	if assertions.Kind(a.T, expectedKind, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1359,7 +1359,7 @@ func (a *Assertions) Lenf(object any, length int, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Len(a.T, object, length, forwardArgs(msg, args)) {
+	if assertions.Len(a.T, object, length, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1387,7 +1387,7 @@ func (a *Assertions) Lessf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Less(a.T, e1, e2, forwardArgs(msg, args)) {
+	if assertions.Less(a.T, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1415,7 +1415,7 @@ func (a *Assertions) LessOrEqualf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.LessOrEqual(a.T, e1, e2, forwardArgs(msg, args)) {
+	if assertions.LessOrEqual(a.T, e1, e2, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1443,7 +1443,7 @@ func (a *Assertions) Negativef(e any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Negative(a.T, e, forwardArgs(msg, args)) {
+	if assertions.Negative(a.T, e, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1471,7 +1471,7 @@ func (a *Assertions) Nilf(object any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Nil(a.T, object, forwardArgs(msg, args)) {
+	if assertions.Nil(a.T, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1499,7 +1499,7 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NoError(a.T, err, forwardArgs(msg, args)) {
+	if assertions.NoError(a.T, err, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1527,7 +1527,7 @@ func (a *Assertions) NoFileDescriptorLeakf(tested func(), msg string, args ...an
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NoFileDescriptorLeak(a.T, tested, forwardArgs(msg, args)) {
+	if assertions.NoFileDescriptorLeak(a.T, tested, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1555,7 +1555,7 @@ func (a *Assertions) NoGoRoutineLeakf(tested func(), msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NoGoRoutineLeak(a.T, tested, forwardArgs(msg, args)) {
+	if assertions.NoGoRoutineLeak(a.T, tested, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1583,7 +1583,7 @@ func (a *Assertions) NotBlockedf(ch any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotBlocked(a.T, ch, forwardArgs(msg, args)) {
+	if assertions.NotBlocked(a.T, ch, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1611,7 +1611,7 @@ func (a *Assertions) NotContainsf(s any, contains any, msg string, args ...any) 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotContains(a.T, s, contains, forwardArgs(msg, args)) {
+	if assertions.NotContains(a.T, s, contains, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1639,7 +1639,7 @@ func (a *Assertions) NotElementsMatchf(listA any, listB any, msg string, args ..
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotElementsMatch(a.T, listA, listB, forwardArgs(msg, args)) {
+	if assertions.NotElementsMatch(a.T, listA, listB, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1667,7 +1667,7 @@ func (a *Assertions) NotEmptyf(object any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEmpty(a.T, object, forwardArgs(msg, args)) {
+	if assertions.NotEmpty(a.T, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1695,7 +1695,7 @@ func (a *Assertions) NotEqualf(expected any, actual any, msg string, args ...any
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEqual(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotEqual(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1723,7 +1723,7 @@ func (a *Assertions) NotEqualValuesf(expected any, actual any, msg string, args 
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotEqualValues(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotEqualValues(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1751,7 +1751,7 @@ func (a *Assertions) NotErrorAsf(err error, target any, msg string, args ...any)
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotErrorAs(a.T, err, target, forwardArgs(msg, args)) {
+	if assertions.NotErrorAs(a.T, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1779,7 +1779,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...an
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotErrorIs(a.T, err, target, forwardArgs(msg, args)) {
+	if assertions.NotErrorIs(a.T, err, target, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1807,7 +1807,7 @@ func (a *Assertions) NotImplementsf(interfaceObject any, object any, msg string,
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotImplements(a.T, interfaceObject, object, forwardArgs(msg, args)) {
+	if assertions.NotImplements(a.T, interfaceObject, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1835,7 +1835,7 @@ func (a *Assertions) NotKindf(expectedKind reflect.Kind, object any, msg string,
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotKind(a.T, expectedKind, object, forwardArgs(msg, args)) {
+	if assertions.NotKind(a.T, expectedKind, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1863,7 +1863,7 @@ func (a *Assertions) NotNilf(object any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotNil(a.T, object, forwardArgs(msg, args)) {
+	if assertions.NotNil(a.T, object, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1891,7 +1891,7 @@ func (a *Assertions) NotPanicsf(f func(), msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotPanics(a.T, f, forwardArgs(msg, args)) {
+	if assertions.NotPanics(a.T, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1919,7 +1919,7 @@ func (a *Assertions) NotRegexpf(rx any, actual any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotRegexp(a.T, rx, actual, forwardArgs(msg, args)) {
+	if assertions.NotRegexp(a.T, rx, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1947,7 +1947,7 @@ func (a *Assertions) NotSamef(expected any, actual any, msg string, args ...any)
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotSame(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.NotSame(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -1975,7 +1975,7 @@ func (a *Assertions) NotSubsetf(list any, subset any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotSubset(a.T, list, subset, forwardArgs(msg, args)) {
+	if assertions.NotSubset(a.T, list, subset, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2003,7 +2003,7 @@ func (a *Assertions) NotZerof(i any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.NotZero(a.T, i, forwardArgs(msg, args)) {
+	if assertions.NotZero(a.T, i, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2031,7 +2031,7 @@ func (a *Assertions) Panicsf(f func(), msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Panics(a.T, f, forwardArgs(msg, args)) {
+	if assertions.Panics(a.T, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2059,7 +2059,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f func(), msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.PanicsWithError(a.T, errString, f, forwardArgs(msg, args)) {
+	if assertions.PanicsWithError(a.T, errString, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2087,7 +2087,7 @@ func (a *Assertions) PanicsWithValuef(expected any, f func(), msg string, args .
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.PanicsWithValue(a.T, expected, f, forwardArgs(msg, args)) {
+	if assertions.PanicsWithValue(a.T, expected, f, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2115,7 +2115,7 @@ func (a *Assertions) Positivef(e any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Positive(a.T, e, forwardArgs(msg, args)) {
+	if assertions.Positive(a.T, e, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2143,7 +2143,7 @@ func (a *Assertions) Regexpf(rx any, actual any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Regexp(a.T, rx, actual, forwardArgs(msg, args)) {
+	if assertions.Regexp(a.T, rx, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2171,7 +2171,7 @@ func (a *Assertions) Samef(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Same(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.Same(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2199,7 +2199,7 @@ func (a *Assertions) Subsetf(list any, subset any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Subset(a.T, list, subset, forwardArgs(msg, args)) {
+	if assertions.Subset(a.T, list, subset, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2227,7 +2227,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.True(a.T, value, forwardArgs(msg, args)) {
+	if assertions.True(a.T, value, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2255,7 +2255,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.WithinDuration(a.T, expected, actual, delta, forwardArgs(msg, args)) {
+	if assertions.WithinDuration(a.T, expected, actual, delta, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2283,7 +2283,7 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.WithinRange(a.T, actual, start, end, forwardArgs(msg, args)) {
+	if assertions.WithinRange(a.T, actual, start, end, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2311,7 +2311,7 @@ func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ..
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLEq(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.YAMLEq(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2339,7 +2339,7 @@ func (a *Assertions) YAMLEqBytesf(expected []byte, actual []byte, msg string, ar
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.YAMLEqBytes(a.T, expected, actual, forwardArgs(msg, args)) {
+	if assertions.YAMLEqBytes(a.T, expected, actual, forwardArgs(msg, args)...) {
 		return
 	}
 
@@ -2367,7 +2367,7 @@ func (a *Assertions) Zerof(i any, msg string, args ...any) {
 	if h, ok := a.T.(H); ok {
 		h.Helper()
 	}
-	if assertions.Zero(a.T, i, forwardArgs(msg, args)) {
+	if assertions.Zero(a.T, i, forwardArgs(msg, args)...) {
 		return
 	}
 


### PR DESCRIPTION
## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
